### PR TITLE
Get builds and tests working on Linux

### DIFF
--- a/approvals/Makefile
+++ b/approvals/Makefile
@@ -2,7 +2,7 @@
 # Makefile
 ###################################
 CC = g++
-INCLUDE = -I ../igloo
+INCLUDE = -isystem  ../igloo
 CFLAGS = -lpthread -Wall -std=c++14
 CHECK = echo cppcheck -v --inline-suppr --enable=all
 FORMAT = echo astyle -YfDHUbps4yj -k3

--- a/approvals/namers/IglooNamerFactory.h
+++ b/approvals/namers/IglooNamerFactory.h
@@ -6,7 +6,9 @@
 #include <igloo/igloo.h>
 #include <unistd.h>
 #include "Namer.h"
-#include <mach-o/dyld.h>
+#ifdef __APPLE__
+    #include <mach-o/dyld.h>
+#endif
 
 class IglooNamerFactory
 {
@@ -15,12 +17,8 @@ private:
     static std::string currentContext;
     static std::string currentSpec;
 
+#ifdef __APPLE__
     static std::string ExePath()
-    {
-
-        return ExePathMac();
-    }
-    static std::string ExePathMac()
     {
         char buf[512];
         bzero( buf, 512 );
@@ -34,8 +32,10 @@ private:
         std::string path( buf );
         return path;
     }
+#endif
 
-    static std::string ExePathLinux()
+#ifdef __linux__
+    static std::string ExePath()
     {
         char buf[512];
         bzero( buf, 512 );
@@ -49,6 +49,7 @@ private:
         std::string path( buf );
         return path;
     }
+#endif
 
     static std::string FullTestName()
     {

--- a/approvals/test/NamerTests.cpp
+++ b/approvals/test/NamerTests.cpp
@@ -27,7 +27,12 @@ Context( DescribeAnIglooNamerFactory )
 
     Spec( ItCanGiveYouTheTestDirectory )
     {
+#ifdef __APPLE__
         Assert::That( IglooNamerFactory::TestDirectory(), EndsWith("approvals/./test/bin") );
+#endif
+#ifdef __linux__
+        Assert::That( IglooNamerFactory::TestDirectory(), EndsWith("approvals/test/bin") );
+#endif
     }
 
     Spec( ItIncludesFileContextAndSpecNames )


### PR DESCRIPTION
The change in `approvals/namers/IglooNamerFactory.h` leaves in place some code repetition for now, to keep it as a localised change, for later tidying when pairing....

The change in `approvals/test/NamerTests.cpp` should keep the tests passing on both Linux and Mac, but it does suggest that the Mac implementation may need a little more work to remove the extra `./` from the expected result.... unless you decide it's harmless?