### PR TITLE
Make library usable with Cmake add_subdirectory() of source tree.

### DIFF
--- a/ApprovalTests/CMakeLists.txt
+++ b/ApprovalTests/CMakeLists.txt
@@ -1,32 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests CXX)
 set(CMAKE_CXX_STANDARD 11)
-set(SOURCE_FILES
-        ApprovalException.h
-        Approvals.h
-        ApprovalWriter.h
-        Catch2Approvals.h
-        FileApprover.h
-        FileUtils.h
-        Macros.h
-        StringWriter.h
-        SystemUtils.h
-        CombinationApprovals.h
-        comparators/ApprovalComparator.h
-        comparators/TextFileComparator.h
-        namers/ApprovalNamer.h
-        namers/ApprovalTestNamer.h
-        reporters/CommandLauncher.h
-        reporters/ClipboardReporter.h
-        reporters/Reporter.h 
-        reporters/FirstWorkingReporter.h
-        reporters/DiffReporter.h
-        reporters/DiffPrograms.h
-        reporters/DiffInfo.h
-        reporters/WindowsReporters.h
-        reporters/MacReporters.h
-        reporters/LinuxReporters.h StringUtils.h reporters/GenericDiffReporter.h reporters/CommandReporter.h OkraApprovals.h
-        GoogleTestApprovals.h
-        reporters/SystemLauncher.h writers/ExistingFile.h writers/ExistingFile.h namers/ExistingFileNamer.h reporters/CombinationReporter.h)
-add_library(${PROJECT_NAME} ${SOURCE_FILES} )
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME}
+        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/ApprovalTests_Catch1_Tests/ApprovalsTests.cpp
+++ b/ApprovalTests_Catch1_Tests/ApprovalsTests.cpp
@@ -1,5 +1,5 @@
 #include "../lib/catch.1.9.0.hpp"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/Approvals.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch1_Tests/CMakeLists.txt
+++ b/ApprovalTests_Catch1_Tests/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests_Catch1_Tests)
 set(CMAKE_CXX_STANDARD 17)
-set(SOURCE_FILES
+add_executable(${PROJECT_NAME}
         main.cpp
-        ApprovalsTests.cpp
-        )
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
+        ApprovalsTests.cpp)
+target_link_libraries(${PROJECT_NAME} ApprovalTests)
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/ApprovalTests_Catch1_Tests/main.cpp
+++ b/ApprovalTests_Catch1_Tests/main.cpp
@@ -2,5 +2,5 @@
 #include "../lib/catch.1.9.0.hpp"
 
 #define APPROVALS_CATCH
-#include "../ApprovalTests/Catch2Approvals.h"
+#include <ApprovalTests/Catch2Approvals.h>
 

--- a/ApprovalTests_Catch2_Tests/ApprovalExceptionTests.cpp
+++ b/ApprovalTests_Catch2_Tests/ApprovalExceptionTests.cpp
@@ -1,7 +1,7 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/ApprovalException.h"
-#include "../ApprovalTests/Approvals.h"
-#include "../ApprovalTests/reporters/QuietReporter.h"
+#include <ApprovalTests/ApprovalException.h>
+#include <ApprovalTests/Approvals.h>
+#include <ApprovalTests/reporters/QuietReporter.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/ApprovalTests.hpp
+++ b/ApprovalTests_Catch2_Tests/ApprovalTests.hpp
@@ -3,6 +3,6 @@
 #ifndef APPROVALTESTS_CPP_APPROVALTESTS_H
 #define APPROVALTESTS_CPP_APPROVALTESTS_H
 
-#include "../ApprovalTests/Catch2Approvals.h"
+#include <ApprovalTests/Catch2Approvals.h>
 
 #endif //APPROVALTESTS_CPP_APPROVALTESTS_H

--- a/ApprovalTests_Catch2_Tests/ApprovalsTests.cpp
+++ b/ApprovalTests_Catch2_Tests/ApprovalsTests.cpp
@@ -1,6 +1,6 @@
 #include <ostream>
 #include "Catch.hpp"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/Approvals.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/CMakeLists.txt
+++ b/ApprovalTests_Catch2_Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests_Catch2_Tests)
 set(CMAKE_CXX_STANDARD 17)
-set(SOURCE_FILES
+add_executable(${PROJECT_NAME}
         main.cpp
         reporters/ReporterTests.cpp
         ApprovalExceptionTests.cpp
@@ -16,5 +16,5 @@ set(SOURCE_FILES
         ToStringExample.cpp
         StyleGuide.h
         )
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
+target_link_libraries(${PROJECT_NAME} ApprovalTests)
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/ApprovalTests_Catch2_Tests/CombinationTests.cpp
+++ b/ApprovalTests_Catch2_Tests/CombinationTests.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <string>
 #include <ostream>
-#include "../ApprovalTests/CombinationApprovals.h"
+#include <ApprovalTests/CombinationApprovals.h>
 #include "reporters/FakeReporter.h"
 
 std::ostream &operator<<(std::ostream &os, const std::pair<std::string, int>& pair)

--- a/ApprovalTests_Catch2_Tests/FileApproverTests.cpp
+++ b/ApprovalTests_Catch2_Tests/FileApproverTests.cpp
@@ -1,9 +1,9 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/StringWriter.h"
+#include <ApprovalTests/StringWriter.h>
 #include "reporters/TestReporter.h"
-#include "../ApprovalTests/namers/ApprovalTestNamer.h"
-#include "../ApprovalTests/FileApprover.h"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/namers/ApprovalTestNamer.h>
+#include <ApprovalTests/FileApprover.h>
+#include <ApprovalTests/Approvals.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/NamerTests.cpp
+++ b/ApprovalTests_Catch2_Tests/NamerTests.cpp
@@ -1,7 +1,7 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/namers/ApprovalTestNamer.h"
-#include "../ApprovalTests/StringUtils.h"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/namers/ApprovalTestNamer.h>
+#include <ApprovalTests/StringUtils.h>
+#include <ApprovalTests/Approvals.h>
 
 using namespace std;
 using Catch::Matchers::EndsWith;

--- a/ApprovalTests_Catch2_Tests/StringUtilsTests.cpp
+++ b/ApprovalTests_Catch2_Tests/StringUtilsTests.cpp
@@ -1,5 +1,5 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/StringUtils.h"
+#include <ApprovalTests/StringUtils.h>
 
 
 TEST_CASE("TestLowerCase") {

--- a/ApprovalTests_Catch2_Tests/StringWriterTests.cpp
+++ b/ApprovalTests_Catch2_Tests/StringWriterTests.cpp
@@ -1,5 +1,5 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/StringWriter.h"
+#include <ApprovalTests/StringWriter.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/SystemUtilsTests.cpp
+++ b/ApprovalTests_Catch2_Tests/SystemUtilsTests.cpp
@@ -1,6 +1,6 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/SystemUtils.h"
-#include "../ApprovalTests/StringUtils.h"
+#include <ApprovalTests/SystemUtils.h>
+#include <ApprovalTests/StringUtils.h>
 
 TEST_CASE("ItCanFixCaseOfFileNameOnWindows")
 {

--- a/ApprovalTests_Catch2_Tests/ToStringExample.cpp
+++ b/ApprovalTests_Catch2_Tests/ToStringExample.cpp
@@ -1,5 +1,5 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/Approvals.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/VectorTests.cpp
+++ b/ApprovalTests_Catch2_Tests/VectorTests.cpp
@@ -1,5 +1,5 @@
 #include "Catch.hpp"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/Approvals.h>
 #include <vector>
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/reporters/DoNothingLauncher.h
+++ b/ApprovalTests_Catch2_Tests/reporters/DoNothingLauncher.h
@@ -1,7 +1,7 @@
 #ifndef DONOTHINGLAUNCHER_H
 #define DONOTHINGLAUNCHER_H
 
-#include "../../ApprovalTests/reporters/CommandLauncher.h"
+#include <ApprovalTests/reporters/CommandLauncher.h>
 
 #include <string>
 #include <vector>

--- a/ApprovalTests_Catch2_Tests/reporters/FakeReporter.h
+++ b/ApprovalTests_Catch2_Tests/reporters/FakeReporter.h
@@ -1,7 +1,7 @@
 #ifndef APPROVALTESTS_CPP_FAKEREPORTER_H
 #define APPROVALTESTS_CPP_FAKEREPORTER_H
 
-#include "../../ApprovalTests/reporters/Reporter.h"
+#include <ApprovalTests/reporters/Reporter.h>
 
 class FakeReporter : public Reporter {
 public:

--- a/ApprovalTests_Catch2_Tests/reporters/ReporterTests.cpp
+++ b/ApprovalTests_Catch2_Tests/reporters/ReporterTests.cpp
@@ -2,9 +2,9 @@
 #include "Catch.hpp"
 #include "TestReporter.h"
 #include "FakeReporter.h"
-#include "../../ApprovalTests/reporters/FirstWorkingReporter.h"
-#include "../../ApprovalTests/reporters/ClipboardReporter.h"
-#include "../../ApprovalTests/reporters/CombinationReporter.h"
+#include <ApprovalTests/reporters/FirstWorkingReporter.h>
+#include <ApprovalTests/reporters/ClipboardReporter.h>
+#include <ApprovalTests/reporters/CombinationReporter.h>
 
 using namespace std;
 

--- a/ApprovalTests_Catch2_Tests/reporters/TestReporter.h
+++ b/ApprovalTests_Catch2_Tests/reporters/TestReporter.h
@@ -1,7 +1,7 @@
 #ifndef APPROVALTESTS_CPP_TESTREPORTER_H
 #define APPROVALTESTS_CPP_TESTREPORTER_H
 
-#include "../../ApprovalTests/reporters/GenericDiffReporter.h"
+#include <ApprovalTests/reporters/GenericDiffReporter.h>
 #include "DoNothingLauncher.h"
 
 class TestReporter : public CommandReporter {

--- a/ApprovalTests_GoogleTest_Tests/ApprovalTests.hpp
+++ b/ApprovalTests_GoogleTest_Tests/ApprovalTests.hpp
@@ -3,6 +3,6 @@
 #ifndef APPROVALTESTS_CPP_APPROVALTESTS_H
 #define APPROVALTESTS_CPP_APPROVALTESTS_H
 
-#include "../ApprovalTests/GoogleTestApprovals.h"
+#include <ApprovalTests/GoogleTestApprovals.h>
 
 #endif //APPROVALTESTS_CPP_APPROVALTESTS_H

--- a/ApprovalTests_GoogleTest_Tests/CMakeLists.txt
+++ b/ApprovalTests_GoogleTest_Tests/CMakeLists.txt
@@ -1,20 +1,19 @@
 cmake_minimum_required(VERSION 3.8)
 project(ApprovalTests_GoogleTest_Tests)
 set(CMAKE_CXX_STANDARD 11)
-set(SOURCE_FILES
+add_executable(${PROJECT_NAME}
         main.cpp
         GoogleTestApprovalsTests.cpp
-		GoogleNamerTest.cpp
+        GoogleNamerTest.cpp
         )
+target_link_libraries(${PROJECT_NAME} ApprovalTests gtest gtest_main)
 
 if(MSVC)
     # Suppress compiler warnings, until I can access a newer Google Test build
     #   C:\Users\Clare\Documents\Programming\tools\gtest\gtest-1.6.0-vs2015-update2\include\gtest/gtest-printers.h(497): warning C4996: 'std::tr1': warning STL4002: The non-Standard std::tr1 namespace and TR1-only machinery are deprecated and will be REMOVED. You can define _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING to acknowledge that you have received this warning.
     #   C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\tuple(1137): note: see declaration of 'std::tr1'
-    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 endif()
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} )
-
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
-target_link_libraries(${PROJECT_NAME} gtest gtest_main)

--- a/ApprovalTests_GoogleTest_Tests/GoogleNamerTest.cpp
+++ b/ApprovalTests_GoogleTest_Tests/GoogleNamerTest.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "../ApprovalTests/namers/ApprovalTestNamer.h"
+#include <ApprovalTests/namers/ApprovalTestNamer.h>
 
 TEST(GoogleNamerTest, ItDropsFirstNameWhenItEqualsTheFilename)
 {

--- a/ApprovalTests_GoogleTest_Tests/GoogleTestApprovalsTests.cpp
+++ b/ApprovalTests_GoogleTest_Tests/GoogleTestApprovalsTests.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "../ApprovalTests/Approvals.h"
+#include <ApprovalTests/Approvals.h>
 
 TEST(GoogleTestApprovalsTests, YouCanVerifyText)
 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,35 @@
 cmake_minimum_required(VERSION 3.8)
+
+# disable testsuite if used via add_subdirectory()
+if(NOT DEFINED PROJECT_NAME)
+    set(NOT_SUBPROJECT ON)
+endif()
+
 project(ApprovalTests.cpp)
-set(CMAKE_CXX_STANDARD 17)
-
-# Download and unpack googletest at configure time
-configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
-execute_process(COMMAND "${CMAKE_COMMAND}" --build .
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
-
-# Prevent GoogleTest from overriding our compiler/linker options
-# when building with Visual Studio
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-# Add googletest directly to our build. This adds
-# the following targets: gtest, gtest_main, gmock
-# and gmock_main
-add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src" "${CMAKE_BINARY_DIR}/googletest-build")
-
-include_directories(lib)
-enable_testing()
-
 add_subdirectory(ApprovalTests)
-add_subdirectory(ApprovalTests_Catch1_Tests)
-add_subdirectory(ApprovalTests_Catch2_Tests)
-add_subdirectory(ApprovalTests_GoogleTest_Tests)
+
+
+if (NOT_SUBPROJECT)
+    # Download and unpack googletest at configure time
+    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+    execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
+    execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
+
+    # Prevent GoogleTest from overriding our compiler/linker options
+    # when building with Visual Studio
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+    # Add googletest directly to our build. This adds
+    # the following targets: gtest, gtest_main, gmock
+    # and gmock_main
+    add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
+                     "${CMAKE_BINARY_DIR}/googletest-build")
+    include_directories(lib) # for Catch
+
+    enable_testing()
+    add_subdirectory(ApprovalTests_Catch1_Tests)
+    add_subdirectory(ApprovalTests_Catch2_Tests)
+    add_subdirectory(ApprovalTests_GoogleTest_Tests)
+endif()


### PR DESCRIPTION
Downstream users would do the following:

1. `add_subdirectory(ApprovalTests.cpp/ApprovalTests)`
2. `target_link_libraries(my_project ApprovalTests)`

And then in sources they would include as

3. `#include <ApprovalTests/Approvals.h>`

This is a common pattern. The tests are modified to use this pattern.