### PR TITLE
Resharper cpp fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/html/
 CMakeLists.txt.user
 *.bak
 .DS_Store
+[Oo]ut/build

--- a/ApprovalTests/Approvals.h
+++ b/ApprovalTests/Approvals.h
@@ -64,7 +64,7 @@ public:
         {
             message = e.what();
         }
-        Approvals::verify(message, reporter);
+        verify(message, reporter);
     }
 
     template<typename Iterator>

--- a/ApprovalTests/launchers/SystemLauncher.h
+++ b/ApprovalTests/launchers/SystemLauncher.h
@@ -3,7 +3,7 @@
 #define APPROVALTESTS_CPP_SYSTEMLAUNCHER_H
 
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 #include "ApprovalTests/utilities/SystemUtils.h"
 #include "ApprovalTests/utilities/FileUtils.h"

--- a/ApprovalTests/reporters/GenericDiffReporter.h
+++ b/ApprovalTests/reporters/GenericDiffReporter.h
@@ -16,7 +16,7 @@ public:
     {
         checkForCygwin();
     }
-    GenericDiffReporter(const DiffInfo& info) : CommandReporter(info.getProgramForOs().c_str(), &launcher)
+    GenericDiffReporter(const DiffInfo& info) : CommandReporter(info.getProgramForOs(), &launcher)
     {
         checkForCygwin();
     }

--- a/ApprovalTests/reporters/LinuxReporters.h
+++ b/ApprovalTests/reporters/LinuxReporters.h
@@ -10,12 +10,12 @@ namespace Linux
 {
     class KDiff3Reporter : public GenericDiffReporter {
     public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Linux::KDIFF3()) {};
+        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Linux::KDIFF3()) {}
     };
 
     class MeldReporter : public GenericDiffReporter {
     public:
-        MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD()) {};
+        MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD()) {}
     };
 
     class LinuxDiffReporter : public FirstWorkingReporter

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -9,17 +9,17 @@ namespace ApprovalTests {
 namespace Windows {
     class BeyondCompare3Reporter : public GenericDiffReporter {
     public:
-        BeyondCompare3Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3()) {};
+        BeyondCompare3Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3()) {}
     };
 
   class VisualStudioCodeReporter : public GenericDiffReporter {
     public:
-      VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Windows::VS_CODE()) {};
+      VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Windows::VS_CODE()) {}
     };
 
     class BeyondCompare4Reporter : public GenericDiffReporter {
     public:
-        BeyondCompare4Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4()) {};
+        BeyondCompare4Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4()) {}
     };
 
     class BeyondCompareReporter : public FirstWorkingReporter {
@@ -30,12 +30,12 @@ namespace Windows {
 
     class TortoiseImageDiffReporter : public GenericDiffReporter {
     public:
-        TortoiseImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_IMAGE_DIFF()) {};
+        TortoiseImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_IMAGE_DIFF()) {}
     };
 
     class TortoiseTextDiffReporter : public GenericDiffReporter {
     public:
-        TortoiseTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF()) {};
+        TortoiseTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF()) {}
     };
 
     class TortoiseDiffReporter : public FirstWorkingReporter {
@@ -47,22 +47,22 @@ namespace Windows {
 
     class WinMergeReporter : public GenericDiffReporter {
     public:
-        WinMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::WIN_MERGE_REPORTER()) {};
+        WinMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::WIN_MERGE_REPORTER()) {}
     };
 
     class AraxisMergeReporter : public GenericDiffReporter {
     public:
-        AraxisMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE()) {};
+        AraxisMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE()) {}
     };
 
     class CodeCompareReporter : public GenericDiffReporter {
     public:
-        CodeCompareReporter() : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE()) {};
+        CodeCompareReporter() : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE()) {}
     };
 
     class KDiff3Reporter : public GenericDiffReporter {
     public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Windows::KDIFF3()) {};
+        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Windows::KDIFF3()) {}
     };
 
     class WindowsDiffReporter : public FirstWorkingReporter {


### PR DESCRIPTION
Apply some simple (non-controversial) fixes that ReSharper C++ suggested. 

There is also a .gitignore change that makes life a bit easier when working with VS2019

