### PR TITLE
Fix CMake warnings

### DIFF
--- a/tests/Catch2_Tests/CMakeLists.txt
+++ b/tests/Catch2_Tests/CMakeLists.txt
@@ -33,7 +33,12 @@ target_link_libraries(${PROJECT_NAME} ApprovalTests catch2)
 target_compile_definitions(${PROJECT_NAME} PRIVATE CATCH_CONFIG_FAST_COMPILE)
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        /W4
+        /WX
+        )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE
         -Wall
         -Wextra

--- a/tests/Catch2_Tests/CMakeLists.txt
+++ b/tests/Catch2_Tests/CMakeLists.txt
@@ -41,6 +41,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Werror
         )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     target_compile_options(${PROJECT_NAME} PRIVATE
         /W4
         /WX

--- a/tests/DocTest_Tests/CMakeLists.txt
+++ b/tests/DocTest_Tests/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Werror
         )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     target_compile_options(${PROJECT_NAME} PRIVATE
         /W4
         /WX

--- a/tests/DocTest_Tests/CMakeLists.txt
+++ b/tests/DocTest_Tests/CMakeLists.txt
@@ -10,7 +10,12 @@ add_executable(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ApprovalTests doctest)
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        /W4
+        /WX
+        )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE
         -Wall
         -Wextra

--- a/tests/GoogleTest_Tests/CMakeLists.txt
+++ b/tests/GoogleTest_Tests/CMakeLists.txt
@@ -11,7 +11,12 @@ target_link_libraries(${PROJECT_NAME} ApprovalTests gtest gtest_main)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        /W4
+        /WX
+        )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE
         -Wall
         -Wextra

--- a/tests/GoogleTest_Tests/CMakeLists.txt
+++ b/tests/GoogleTest_Tests/CMakeLists.txt
@@ -19,6 +19,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Werror
         )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     target_compile_options(${PROJECT_NAME} PRIVATE
         /W4
         /WX


### PR DESCRIPTION
I am far from a CMake expert but I think these changes should resolve warnings/error when using Visual Studio in MSVC and Clang-cl mode.

There is an outstanding issue when compiling with X64-Debug on MSVC 

Command line warning D9025: overriding '/ZI' with '/Zi'

I think this is coming from  googletest but haven't tracked it down yet.

