### PR TITLE
Create github_actions_build.yml

### DIFF
--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -6,10 +6,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
+        os: [windows-latest, windows-2016, ubuntu-latest, macOS-latest]
         include:
         - os: windows-latest
           generator: '"Visual Studio 16 2019"'
+        - os: windows-2016
+          generator: '"Visual Studio 15 2017"' 
         - os: ubuntu-latest
           generator: '"Unix Makefiles"'
         - os: macOS-latest

--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        include:
+        - os: windows-latest
+          generator: '"Visual Studio 16 2019"'
+        - os: ubuntu-latest
+          generator: '"Unix Makefiles"'
+        - os: macOS-latest
+          generator: '"Unix Makefiles"'  
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - name: cmake
+      run: cmake -G ${{ matrix.generator }}
+    - name: build
+      run: cmake --build .
+    - name: test
+      run: ctest --verbose --parallel 4 -C Debug


### PR DESCRIPTION
This should partially address [#31](https://github.com/approvals/ApprovalTests.cpp/issues/31). It builds with VS2019 on Windows, GCC 7.4.0 on Ubuntu and AppleClang 10.0.1 on OSX so whilst not a complete set it does use three different compilers so is a start...

I think the badge can be added using 
`![](https://github.com/approvals/ApprovalTests.cpp/workflows/build/badge.svg)`
