### PR TITLE
F Update to doctest 2.3.5

### DIFF
--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -25,7 +25,7 @@ namespace {
         // called when a test case is started (safe to cache a pointer to the input)
         virtual void test_case_start(const doctest::TestCaseData &) override {}
 
-#if DOCTEST_VERSION >= 20305
+#if 20305 <= DOCTEST_VERSION
         // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
         virtual void test_case_reenter(const doctest::TestCaseData&) override {}
 #endif

--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -25,6 +25,9 @@ namespace {
         // called when a test case is started (safe to cache a pointer to the input)
         virtual void test_case_start(const doctest::TestCaseData &) override {}
 
+        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+        virtual void test_case_reenter(const doctest::TestCaseData&) override {}
+        
         // called when a test case has ended
         virtual void test_case_end(const doctest::CurrentTestCaseStats &) override {}
 

--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -26,7 +26,7 @@ namespace {
         virtual void test_case_start(const doctest::TestCaseData &) override {}
 
         // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const doctest::TestCaseData&) override {}
+        virtual void test_case_reenter(const doctest::TestCaseData&) /*override*/ {} // Not override, to support doctest v2.3.4
         
         // called when a test case has ended
         virtual void test_case_end(const doctest::CurrentTestCaseStats &) override {}

--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -25,9 +25,11 @@ namespace {
         // called when a test case is started (safe to cache a pointer to the input)
         virtual void test_case_start(const doctest::TestCaseData &) override {}
 
+#if DOCTEST_VERSION >= 20305
         // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const doctest::TestCaseData&) /*override*/ {} // Not override, to support doctest v2.3.4
-        
+        virtual void test_case_reenter(const doctest::TestCaseData&) override {}
+#endif
+
         // called when a test case has ended
         virtual void test_case_end(const doctest::CurrentTestCaseStats &) override {}
 

--- a/third_party/doctest/doctest.h
+++ b/third_party/doctest/doctest.h
@@ -1,1 +1,1 @@
-#include "doctest.2.3.4.hpp"
+#include "doctest.2.3.5.h"


### PR DESCRIPTION
## Description

Makes ApprovalTests.cpp work with the latest version of doctest - 2.3.5.

https://github.com/onqtam/doctest/releases/tag/2.3.5

## The solution

There is a new virtual method `test_case_reenter()` added to `doctest::IReporter`, so I added an empty implementation of that, in order to get our code to work with the new version...

## Comments

For consistency, I added this line:

```cpp
        virtual void test_case_reenter(const doctest::TestCaseData&) override {}
```

By including the `override`, this requires users of Approval Tests to be building against doctest 2.3.5...

We could decide we wanted to keep the option to build against 2.3.4 - and so remove `override`.



