### PR TITLE
Unify Reporter enable_ifs

### DIFF
--- a/ApprovalTests/Approvals.h
+++ b/ApprovalTests/Approvals.h
@@ -61,7 +61,7 @@ public:
     template<
         typename T,
         typename Function,
-        typename = Detail::IsNotDerivedFromReporter<Function>>
+        typename = Detail::EnableIfNotDerivedFromReporter<Function>>
     static void verify(const T& contents,
                        Function converter,
                        const Reporter &reporter = DefaultReporter())
@@ -74,7 +74,7 @@ public:
     template<
         typename T,
         typename Function,
-        typename = Detail::IsNotDerivedFromReporter<Function>>
+        typename = Detail::EnableIfNotDerivedFromReporter<Function>>
     static void verifyWithExtension(const T& contents,
                        Function converter,
                        const std::string& fileExtensionWithDot,

--- a/ApprovalTests/Approvals.h
+++ b/ApprovalTests/Approvals.h
@@ -61,7 +61,7 @@ public:
     template<
         typename T,
         typename Function,
-        typename = IsNotDerivedFromReporter<Function>>
+        typename = Detail::IsNotDerivedFromReporter<Function>>
     static void verify(const T& contents,
                        Function converter,
                        const Reporter &reporter = DefaultReporter())
@@ -74,7 +74,7 @@ public:
     template<
         typename T,
         typename Function,
-        typename = IsNotDerivedFromReporter<Function>>
+        typename = Detail::IsNotDerivedFromReporter<Function>>
     static void verifyWithExtension(const T& contents,
                        Function converter,
                        const std::string& fileExtensionWithDot,

--- a/ApprovalTests/CombinationApprovals.h
+++ b/ApprovalTests/CombinationApprovals.h
@@ -34,9 +34,6 @@ struct serialize {
         out << ") => " << converter(input1, inputs...) << '\n';
     }
 };
-
-template<class T, class R = void>
-using EnableIfNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, typename std::decay<T>::type>::value, R>::type;
 } // namespace Detail
 
 template<class Converter, class Container, class... Containers>
@@ -48,7 +45,7 @@ void verifyAllCombinations(const Reporter& reporter, Converter&& converter, cons
 }
 
 template<class Converter, class... Containers>
-Detail::EnableIfNotDerivedFromReporter<Converter>
+ApprovalTests::Detail::EnableIfNotDerivedFromReporter<Converter>
 verifyAllCombinations(Converter&& converter, const Containers&... inputs)
 {
     verifyAllCombinations(DefaultReporter(), std::forward<Converter>(converter), inputs...);

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -15,7 +15,7 @@ namespace Detail
 {
 //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
 template<typename T, typename R = void>
-using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, T>::value, R>::type;
+using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, typename std::decay<T>::type>::value, R>::type;
 } // namespace Detail
 }
 

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -11,9 +11,12 @@ public:
     virtual bool report(std::string received, std::string approved) const = 0;
 };
 
+namespace Detail 
+{
 //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
 template<typename T>
 using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, T>::value, int>::type;
+}
 }
 
 #endif

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -15,7 +15,7 @@ namespace Detail
 {
 //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
 template<typename T, typename R = void>
-using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, typename std::decay<T>::type>::value, R>::type;
+using EnableIfNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, typename std::decay<T>::type>::value, R>::type;
 } // namespace Detail
 }
 

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -16,7 +16,7 @@ namespace Detail
 //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
 template<typename T, typename R = void>
 using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, T>::value, R>::type;
-}
+} // namespace Detail
 }
 
 #endif

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -14,8 +14,8 @@ public:
 namespace Detail 
 {
 //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
-template<typename T>
-using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, T>::value, int>::type;
+template<typename T, typename R = void>
+using IsNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, T>::value, R>::type;
 }
 }
 

--- a/tests/Catch2_Tests/reporters/ReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/ReporterTests.cpp
@@ -172,7 +172,7 @@ namespace
 {
     template<
             typename Type,
-            typename = Detail::IsNotDerivedFromReporter<Type, bool>
+            typename = Detail::EnableIfNotDerivedFromReporter<Type, bool>
             >
     bool test_reporter_enabled()
     {
@@ -180,7 +180,7 @@ namespace
     }
 }
 
-TEST_CASE("IsNotDerivedFromReporter")
+TEST_CASE("EnableIfNotDerivedFromReporter")
 {
     test_reporter_enabled<int>();
     test_reporter_enabled<FileApprover>();

--- a/tests/Catch2_Tests/reporters/ReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/ReporterTests.cpp
@@ -168,3 +168,27 @@ TEST_CASE("Unregistering Front Loaded Reporter restores previous")
     REQUIRE(our_reporter1.called == false);
 }
 
+namespace
+{
+    template<
+            typename Type,
+            typename = Detail::IsNotDerivedFromReporter<Type, bool>
+            >
+    bool test_reporter_enabled()
+    {
+        return true;
+    }
+}
+
+TEST_CASE("IsNotDerivedFromReporter")
+{
+    test_reporter_enabled<int>();
+    test_reporter_enabled<FileApprover>();
+
+    // Must not compile:
+//    test_reporter_enabled<Reporter>();
+//    test_reporter_enabled<Reporter&>();
+//    test_reporter_enabled<const Reporter&>();
+//    test_reporter_enabled<FakeReporter&>();
+//    test_reporter_enabled<const FakeReporter&>();
+}


### PR DESCRIPTION
This captures what I learned from this really helpful comment by @mika-fischer

https://github.com/approvals/ApprovalTests.cpp/issues/33#issuecomment-542548813

I make the assumption that no-one is likely to have used the previous IsNotDerivedFromReporter in Reporter.h... To guard against it being used in future, I've followed the practice these days of putting it in to a Detail namespace.

Thanks to the [godbolt link](https://godbolt.org/z/Iblrl8) in Mika's [earlier comment](https://github.com/approvals/ApprovalTests.cpp/issues/33#issuecomment-542077160), I was able to confirm with non-compiling code that the `std::decay` really was needed - and I added a test case that shows two cases that do compile correctly, and some commented out code that doesn't compile, if activated, to at least show my working...
