### PR TITLE
F Added support for TortoiseGit diff tool (text and image)

### DIFF
--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -44,6 +44,11 @@ namespace DiffPrograms {
 
         APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_TEXT_DIFF, DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe", Type::TEXT))
 
+        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_GIT_IMAGE_DIFF,
+              DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitIDiff.exe", "/left:%s /right:%s", Type::IMAGE))
+
+        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_GIT_TEXT_DIFF, DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitMerge.exe", Type::TEXT))
+
         APPROVAL_TESTS_MACROS_ENTRY(WIN_MERGE_REPORTER, DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe", Type::TEXT_AND_IMAGE))
 
         APPROVAL_TESTS_MACROS_ENTRY(ARAXIS_MERGE, DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe", Type::TEXT_AND_IMAGE))

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -51,7 +51,14 @@ namespace Windows {
     class TortoiseDiffReporter : public FirstWorkingReporter {
     public:
         TortoiseDiffReporter() : FirstWorkingReporter(
-                {new TortoiseGitTextDiffReporter(), new TortoiseGitImageDiffReporter(), new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
+                {new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
+        }
+    };
+
+    class TortoiseGitDiffReporter : public FirstWorkingReporter {
+    public:
+        TortoiseGitDiffReporter() : FirstWorkingReporter(
+                {new TortoiseGitTextDiffReporter(), new TortoiseGitImageDiffReporter()}) {
         }
     };
 

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -38,10 +38,20 @@ namespace Windows {
         TortoiseTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF()) {}
     };
 
+    class TortoiseGitTextDiffReporter : public GenericDiffReporter {
+        public:
+        TortoiseGitTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_TEXT_DIFF()) {}
+    };
+
+    class TortoiseGitImageDiffReporter : public GenericDiffReporter {
+        public:
+        TortoiseGitImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_IMAGE_DIFF()) {}
+    };
+
     class TortoiseDiffReporter : public FirstWorkingReporter {
     public:
         TortoiseDiffReporter() : FirstWorkingReporter(
-                {new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
+                {new TortoiseGitTextDiffReporter(), new TortoiseGitImageDiffReporter(), new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
         }
     };
 


### PR DESCRIPTION
This is a small patch to add support for the TortoiseGit diff tools. ApprovalTests.cpp already support TortoiseSVN so it was a small change.

