### PR TITLE
F!! Remove Catch1 support and add `catch2` prefix to all `#includes` for `catch.hpp`

### DIFF
--- a/ApprovalTests/integrations/catch/Catch2Approvals.h
+++ b/ApprovalTests/integrations/catch/Catch2Approvals.h
@@ -13,8 +13,7 @@
 #endif
 
 #ifdef APPROVALS_CATCH
-
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 //namespace ApprovalTests {
 struct Catch2ApprovalListener : Catch::TestEventListenerBase {

--- a/examples/catch2_existing_main/Catch2ApprovalsTests.cpp
+++ b/examples/catch2_existing_main/Catch2ApprovalsTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 using namespace ApprovalTests;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_subdirectory(Catch1_Tests)
 add_subdirectory(Catch2_Tests)
 add_subdirectory(GoogleTest_Tests)
 add_subdirectory(DocTest_Tests)

--- a/tests/Catch1_Tests/ApprovalsTests.YouCanVerifyText.approved.txt
+++ b/tests/Catch1_Tests/ApprovalsTests.YouCanVerifyText.approved.txt
@@ -1,1 +1,0 @@
-My objects!

--- a/tests/Catch1_Tests/ApprovalsTests.cpp
+++ b/tests/Catch1_Tests/ApprovalsTests.cpp
@@ -1,9 +1,0 @@
-#include "catch.hpp"
-#include "ApprovalTests/Approvals.h"
-
-using namespace ApprovalTests;
-
-TEST_CASE("YouCanVerifyText") {
-    Approvals::verify("My objects!");
-}
-

--- a/tests/Catch1_Tests/CMakeLists.txt
+++ b/tests/Catch1_Tests/CMakeLists.txt
@@ -1,7 +1,0 @@
-project(Catch1_Tests)
-set(CMAKE_CXX_STANDARD 17)
-add_executable(${PROJECT_NAME}
-    main.cpp
-    ApprovalsTests.cpp)
-target_link_libraries(${PROJECT_NAME} ApprovalTests catch1)
-add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/Catch1_Tests/main.cpp
+++ b/tests/Catch1_Tests/main.cpp
@@ -1,6 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include "catch.hpp"
-
-#define APPROVALS_CATCH
-#include "ApprovalTests/integrations/catch/Catch2Approvals.h"
-

--- a/tests/Catch2_Tests/ApprovalsTests.cpp
+++ b/tests/Catch2_Tests/ApprovalsTests.cpp
@@ -1,6 +1,6 @@
 #include <ostream>
 #include <stdexcept>
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 using namespace ApprovalTests;

--- a/tests/Catch2_Tests/CombinationTests.cpp
+++ b/tests/Catch2_Tests/CombinationTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include <map>
 #include <vector>
 #include <string>

--- a/tests/Catch2_Tests/VectorTests.cpp
+++ b/tests/Catch2_Tests/VectorTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 #include <vector>
 

--- a/tests/Catch2_Tests/core/ApprovalExceptionTests.cpp
+++ b/tests/Catch2_Tests/core/ApprovalExceptionTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/core/ApprovalException.h"
 #include "ApprovalTests/Approvals.h"
 #include "ApprovalTests/reporters/QuietReporter.h"

--- a/tests/Catch2_Tests/core/FileApproverTests.cpp
+++ b/tests/Catch2_Tests/core/FileApproverTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/writers/StringWriter.h"
 #include "../reporters/TestReporter.h"
 #include "ApprovalTests/namers/ApprovalTestNamer.h"

--- a/tests/Catch2_Tests/documentation/Catch2DocumentationSamples.cpp
+++ b/tests/Catch2_Tests/documentation/Catch2DocumentationSamples.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 #include <vector>
 
@@ -21,7 +21,7 @@ struct Greeting
     explicit Greeting(Nationality nationality) : nationality(nationality)
     {
     }
-    
+
     std::string getGreeting() const
     {
         return getGreetingFor(nationality);

--- a/tests/Catch2_Tests/documentation/CombinationsSampleCode.cpp
+++ b/tests/Catch2_Tests/documentation/CombinationsSampleCode.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include <vector>
 #include <string>
 #include "ApprovalTests/CombinationApprovals.h"

--- a/tests/Catch2_Tests/documentation/OverviewExamples.cpp
+++ b/tests/Catch2_Tests/documentation/OverviewExamples.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 #include <sstream>

--- a/tests/Catch2_Tests/documentation/ToStringExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringExample.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 #include <ostream>

--- a/tests/Catch2_Tests/documentation/ToStringTemplateExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringTemplateExample.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 #include <ostream>

--- a/tests/Catch2_Tests/documentation/ToStringWrapperExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringWrapperExample.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 
 #include <ostream>

--- a/tests/Catch2_Tests/documentation/Tutorial.cpp
+++ b/tests/Catch2_Tests/documentation/Tutorial.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "tests/Catch2_Tests/ApprovalTests.hpp"
 
 #include <string>
@@ -27,7 +27,7 @@ class LibraryBook
 {
 public:
     LibraryBook(std::string title, std::string author, int available_copies,
-                std::string language, int pages, std::string isbn) : 
+                std::string language, int pages, std::string isbn) :
                 title(title), author(author), available_copies(available_copies),
                 language(language), pages(pages), isbn(isbn)
     {
@@ -44,15 +44,15 @@ public:
 // end-snippet
 
 #if 0
-// Non-compiling example for documentation 
+// Non-compiling example for documentation
 TEST_CASE("WritableBooks Does Not Compile")
 {
     // begin-snippet: non_printable_object
     LibraryBook harry_potter(
         "Harry Potter and the Goblet of Fire", "J.K. Rowling",
         30, "English", 752, "978-0439139595");
-    
-    Approvals::verify(harry_potter); // This does not compile 
+
+    Approvals::verify(harry_potter); // This does not compile
     // end-snippet
 }
 #endif
@@ -78,7 +78,7 @@ TEST_CASE("WritableBooks2")
 
     // begin-snippet: printable_object
     Approvals::verify(harry_potter, [](const LibraryBook& b, std::ostream& os){
-        os << 
+        os <<
         "title: " << b.title << "\n" <<
         "author: " << b.author << "\n" <<
         "available_copies: " << b.available_copies << "\n" <<

--- a/tests/Catch2_Tests/namers/NamerTests.cpp
+++ b/tests/Catch2_Tests/namers/NamerTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/namers/ApprovalTestNamer.h"
 #include "ApprovalTests/utilities/StringUtils.h"
 #include "ApprovalTests/Approvals.h"
@@ -79,12 +79,12 @@ TEST_CASE("Use sub-directories clean to previous results")
 {
     auto subdirectory = Approvals::useApprovalsSubdirectory("outer");
     auto namer = Approvals::getDefaultNamer();
-    
+
     {
         auto subdirectory2 = Approvals::useApprovalsSubdirectory("inner");
         REQUIRE_THAT( namer->getApprovedFile(".txt"), Catch::Matchers::Contains( "inner" ) );
     }
-    
+
     REQUIRE_THAT( namer->getApprovedFile(".txt"), Catch::Matchers::Contains( "outer" ) );
 }
 

--- a/tests/Catch2_Tests/reporters/BlockingReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/BlockingReporterTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "ApprovalTests/reporters/BlockingReporter.h"
 

--- a/tests/Catch2_Tests/reporters/CIBuildOnlyReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/CIBuildOnlyReporterTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/reporters/CIBuildOnlyReporterUtils.h"
 #include "ApprovalTests/reporters/QuietReporter.h"
 

--- a/tests/Catch2_Tests/reporters/ReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/ReporterTests.cpp
@@ -1,5 +1,5 @@
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "TestReporter.h"
 #include "FakeReporter.h"
 #include "ApprovalTests/reporters/FirstWorkingReporter.h"
@@ -75,7 +75,7 @@ TEST_CASE("CombinationReporter fails if all fail") {
 TEST_CASE("Launching on PC with cygwin and Araxis Merge")
 {
     // Keeping for manual testing when needed
-    
+
 //    REQUIRE_FALSE(SystemUtils::isWindowsOs());
 //    auto reporter = new Windows::AraxisMergeReporter;
 //    auto namer = Approvals::getDefaultNamer();

--- a/tests/Catch2_Tests/utilities/CartesianProductTests.cpp
+++ b/tests/Catch2_Tests/utilities/CartesianProductTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/utilities/CartesianProduct.h"
 
 #include <string>

--- a/tests/Catch2_Tests/utilities/FileUtilsSystemSpecificTests.cpp
+++ b/tests/Catch2_Tests/utilities/FileUtilsSystemSpecificTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/utilities/FileUtilsSystemSpecific.h"
 #include "ApprovalTests/namers/ApprovalTestNamer.h"
 #include "ApprovalTests/Approvals.h"

--- a/tests/Catch2_Tests/utilities/MachineBlockerTests.cpp
+++ b/tests/Catch2_Tests/utilities/MachineBlockerTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "ApprovalTests/utilities/SystemUtils.h"
 #include "ApprovalTests/Approvals.h"

--- a/tests/Catch2_Tests/utilities/StringUtilsTests.cpp
+++ b/tests/Catch2_Tests/utilities/StringUtilsTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/utilities/StringUtils.h"
 
 using namespace ApprovalTests;

--- a/tests/Catch2_Tests/utilities/SystemUtilsTests.cpp
+++ b/tests/Catch2_Tests/utilities/SystemUtilsTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/Approvals.h"
 #include "ApprovalTests/utilities/SystemUtils.h"
 #include "ApprovalTests/utilities/StringUtils.h"

--- a/tests/Catch2_Tests/writers/StringWriterTests.cpp
+++ b/tests/Catch2_Tests/writers/StringWriterTests.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "ApprovalTests/writers/StringWriter.h"
 #include "ApprovalTests/Approvals.h"
 

--- a/third_party/catch2/CMakeLists.txt
+++ b/third_party/catch2/CMakeLists.txt
@@ -2,4 +2,4 @@ project(catch2 CXX)
 set(CMAKE_CXX_STANDARD 11)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME}
-        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+        INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)


### PR DESCRIPTION
Closes #62 

WARNING: This PR removes support for the Catch 1 unit test framework. See #62 for discussion.

Per the current maintainer for Catch2
> "I strongly recommend going with #include "catch2/catch.hpp"

Adding `catch2` to the path allows ApprovalTests.cpp to work well with the way Catch2 exports target include directories using CMake.

The drawback is that there is no simple/clean way to maintain support for Catch 1 without breaking compatibility. Catch 1 is maintained to support C++98. Both ApprovalTests.cpp and Catch2 depend on features of C++11

The following post describes the changes from Catch 1 to Catch 2: https://levelofindirection.com/blog/catch2-released.html
Theses release notes outline the breaking changes from Catch 1 to Catch 2: https://github.com/catchorg/Catch2/releases/tag/v2.0.1