### PR TITLE
39 clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: None
+AlignAfterOpenBracket: Align
+AlwaysBreakAfterReturnType: None
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+ColumnLimit: 80
+IndentWidth: 4
+FixNamespaceComments: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: BeforeComma
+KeepEmptyLinesAtTheStartOfBlocks: true
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterTemplateKeyword: true
+TabWidth: 4
+UseTab: Never
+...

--- a/ApprovalTests/Approvals.h
+++ b/ApprovalTests/Approvals.h
@@ -14,159 +14,191 @@
 #include "namers/SubdirectoryDisposer.h"
 #include "namers/DefaultNamerDisposer.h"
 
-namespace ApprovalTests {
-class Approvals {
-private:
-    Approvals() = default;
-
-    ~Approvals() = default;
-
-public:
-    static std::shared_ptr<ApprovalNamer> getDefaultNamer()
+namespace ApprovalTests
+{
+    class Approvals
     {
-        return DefaultNamerFactory::getDefaultNamer()();
-    }
+    private:
+        Approvals() = default;
 
-    static void verify(std::string contents, const Reporter &reporter = DefaultReporter()) {
-        verifyWithExtension(contents, ".txt", reporter);
-    }
+        ~Approvals() = default;
 
-    static void verifyWithExtension(std::string contents, const std::string& fileExtensionWithDot, const Reporter &reporter = DefaultReporter()) {
-        StringWriter writer(contents, fileExtensionWithDot);
-        FileApprover::verify(*getDefaultNamer(), writer, reporter);
-    }
-
-    static void verify(const ApprovalWriter& writer, const Reporter &reporter = DefaultReporter())
-    {
-        FileApprover::verify(*getDefaultNamer(), writer, reporter);
-    }
-
-    template<typename T>
-    using IsNotDerivedFromWriter = typename std::enable_if<!std::is_base_of<ApprovalWriter, T>::value, int>::type;
-
-    template<
-            typename T,
-            typename = IsNotDerivedFromWriter<T>>
-    static void verify(const T& contents, const Reporter &reporter = DefaultReporter()) {
-        verify(StringUtils::toString(contents), reporter);
-    }
-
-    template<
-            typename T,
-            typename = IsNotDerivedFromWriter<T>>
-    static void verifyWithExtension(const T& contents, const std::string& fileExtensionWithDot, const Reporter &reporter = DefaultReporter()) {
-        verifyWithExtension(StringUtils::toString(contents), fileExtensionWithDot, reporter);
-    }
-
-    template<
-        typename T,
-        typename Function,
-        typename = Detail::EnableIfNotDerivedFromReporter<Function>>
-    static void verify(const T& contents,
-                       Function converter,
-                       const Reporter &reporter = DefaultReporter())
-    {
-        std::stringstream s;
-        converter(contents, s);
-        verify(s.str(), reporter);
-    }
-
-    template<
-        typename T,
-        typename Function,
-        typename = Detail::EnableIfNotDerivedFromReporter<Function>>
-    static void verifyWithExtension(const T& contents,
-                       Function converter,
-                       const std::string& fileExtensionWithDot,
-                       const Reporter &reporter = DefaultReporter())
-    {
-        std::stringstream s;
-        converter(contents, s);
-        verifyWithExtension(s.str(), fileExtensionWithDot, reporter);
-    }
-
-    static void verifyExceptionMessage(
-        std::function<void(void)> functionThatThrows,
-        const Reporter &reporter = DefaultReporter())
-    {
-        std::string message = "*** no exception thrown ***";
-        try
+    public:
+        static std::shared_ptr<ApprovalNamer> getDefaultNamer()
         {
-            functionThatThrows();
+            return DefaultNamerFactory::getDefaultNamer()();
         }
-        catch(const std::exception& e)
+
+        static void verify(std::string contents,
+                           const Reporter& reporter = DefaultReporter())
         {
-            message = e.what();
+            verifyWithExtension(contents, ".txt", reporter);
         }
-        verify(message, reporter);
-    }
 
-    template<typename Iterator>
-    static void verifyAll(std::string header,
-                          const Iterator &start, const Iterator &finish,
-                          std::function<void(typename Iterator::value_type, std::ostream &)> converter,
-                          const Reporter &reporter = DefaultReporter()) {
-        std::stringstream s;
-        if (!header.empty()) {
-            s << header << "\n\n\n";
+        static void
+        verifyWithExtension(std::string contents,
+                            const std::string& fileExtensionWithDot,
+                            const Reporter& reporter = DefaultReporter())
+        {
+            StringWriter writer(contents, fileExtensionWithDot);
+            FileApprover::verify(*getDefaultNamer(), writer, reporter);
         }
-        for (auto it = start; it != finish; ++it) {
-            converter(*it, s);
-            s << '\n';
+
+        static void verify(const ApprovalWriter& writer,
+                           const Reporter& reporter = DefaultReporter())
+        {
+            FileApprover::verify(*getDefaultNamer(), writer, reporter);
         }
-        verify(s.str(), reporter);
-    }
 
-    template<typename Container>
-    static void verifyAll(std::string header,
-                          const Container &list,
-                          std::function<void(typename Container::value_type, std::ostream &)> converter,
-                          const Reporter &reporter = DefaultReporter()) {
-        verifyAll<typename Container::const_iterator>(header, list.begin(), list.end(), converter, reporter);
-    }
+        template <typename T>
+        using IsNotDerivedFromWriter =
+            typename std::enable_if<!std::is_base_of<ApprovalWriter, T>::value,
+                                    int>::type;
 
-    template<typename T>
-    static void verifyAll(std::string header,
-                          const std::vector<T> &list,
-                          const Reporter &reporter = DefaultReporter()) {
-        int i = 0;
-        verifyAll<std::vector<T>>(header, list, [&](T e, std::ostream &s) { s << "[" << i++ << "] = " << e; },
-                                  reporter);
-    }
+        template <typename T, typename = IsNotDerivedFromWriter<T>>
+        static void verify(const T& contents,
+                           const Reporter& reporter = DefaultReporter())
+        {
+            verify(StringUtils::toString(contents), reporter);
+        }
 
-    template<typename T>
-    static void verifyAll(const std::vector<T> &list,
-                          const Reporter &reporter = DefaultReporter()) {
-        verifyAll<T>("", list, reporter);
-    }
+        template <typename T, typename = IsNotDerivedFromWriter<T>>
+        static void
+        verifyWithExtension(const T& contents,
+                            const std::string& fileExtensionWithDot,
+                            const Reporter& reporter = DefaultReporter())
+        {
+            verifyWithExtension(StringUtils::toString(contents),
+                                fileExtensionWithDot,
+                                reporter);
+        }
 
-    static void verifyExistingFile(const std::string filePath, const Reporter &reporter = DefaultReporter()) {
-        ExistingFile writer(filePath);
-        ExistingFileNamer namer(filePath);
-        FileApprover::verify(namer, writer, reporter);
-    }
+        template <typename T,
+                  typename Function,
+                  typename = Detail::EnableIfNotDerivedFromReporter<Function>>
+        static void verify(const T& contents,
+                           Function converter,
+                           const Reporter& reporter = DefaultReporter())
+        {
+            std::stringstream s;
+            converter(contents, s);
+            verify(s.str(), reporter);
+        }
 
-    static SubdirectoryDisposer useApprovalsSubdirectory(std::string subdirectory = "approval_tests")
-    {
-        return SubdirectoryDisposer(subdirectory);
-    }
+        template <typename T,
+                  typename Function,
+                  typename = Detail::EnableIfNotDerivedFromReporter<Function>>
+        static void
+        verifyWithExtension(const T& contents,
+                            Function converter,
+                            const std::string& fileExtensionWithDot,
+                            const Reporter& reporter = DefaultReporter())
+        {
+            std::stringstream s;
+            converter(contents, s);
+            verifyWithExtension(s.str(), fileExtensionWithDot, reporter);
+        }
 
-    static DefaultReporterDisposer useAsDefaultReporter(const std::shared_ptr<Reporter>& reporter)
-    {
-        return DefaultReporterDisposer(reporter);
-    }
+        static void
+        verifyExceptionMessage(std::function<void(void)> functionThatThrows,
+                               const Reporter& reporter = DefaultReporter())
+        {
+            std::string message = "*** no exception thrown ***";
+            try
+            {
+                functionThatThrows();
+            }
+            catch (const std::exception& e)
+            {
+                message = e.what();
+            }
+            verify(message, reporter);
+        }
 
-    static FrontLoadedReporterDisposer useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
-    {
-        return FrontLoadedReporterDisposer(reporter);
-    }
+        template <typename Iterator>
+        static void verifyAll(std::string header,
+                              const Iterator& start,
+                              const Iterator& finish,
+                              std::function<void(typename Iterator::value_type,
+                                                 std::ostream&)> converter,
+                              const Reporter& reporter = DefaultReporter())
+        {
+            std::stringstream s;
+            if (!header.empty())
+            {
+                s << header << "\n\n\n";
+            }
+            for (auto it = start; it != finish; ++it)
+            {
+                converter(*it, s);
+                s << '\n';
+            }
+            verify(s.str(), reporter);
+        }
 
-    static DefaultNamerDisposer useAsDefaultNamer(NamerCreator namerCreator)
-    {
-        return DefaultNamerDisposer(namerCreator);
-    }
+        template <typename Container>
+        static void verifyAll(std::string header,
+                              const Container& list,
+                              std::function<void(typename Container::value_type,
+                                                 std::ostream&)> converter,
+                              const Reporter& reporter = DefaultReporter())
+        {
+            verifyAll<typename Container::const_iterator>(
+                header, list.begin(), list.end(), converter, reporter);
+        }
 
-};
+        template <typename T>
+        static void verifyAll(std::string header,
+                              const std::vector<T>& list,
+                              const Reporter& reporter = DefaultReporter())
+        {
+            int i = 0;
+            verifyAll<std::vector<T>>(
+                header,
+                list,
+                [&](T e, std::ostream& s) { s << "[" << i++ << "] = " << e; },
+                reporter);
+        }
+
+        template <typename T>
+        static void verifyAll(const std::vector<T>& list,
+                              const Reporter& reporter = DefaultReporter())
+        {
+            verifyAll<T>("", list, reporter);
+        }
+
+        static void
+        verifyExistingFile(const std::string filePath,
+                           const Reporter& reporter = DefaultReporter())
+        {
+            ExistingFile writer(filePath);
+            ExistingFileNamer namer(filePath);
+            FileApprover::verify(namer, writer, reporter);
+        }
+
+        static SubdirectoryDisposer
+        useApprovalsSubdirectory(std::string subdirectory = "approval_tests")
+        {
+            return SubdirectoryDisposer(subdirectory);
+        }
+
+        static DefaultReporterDisposer
+        useAsDefaultReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            return DefaultReporterDisposer(reporter);
+        }
+
+        static FrontLoadedReporterDisposer
+        useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            return FrontLoadedReporterDisposer(reporter);
+        }
+
+        static DefaultNamerDisposer useAsDefaultNamer(NamerCreator namerCreator)
+        {
+            return DefaultNamerDisposer(namerCreator);
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/CombinationApprovals.h
+++ b/ApprovalTests/CombinationApprovals.h
@@ -7,51 +7,67 @@
 #include "ApprovalTests/utilities/CartesianProduct.h"
 #include "Approvals.h"
 
-namespace ApprovalTests {
-namespace CombinationApprovals {
-namespace Detail {
-
-// Write out second or subsequent input value, with preceding comma and space
-struct print_input {
-    std::ostream& out;
-    template<class T>
-    void operator()(const T& input) {
-        out << ", " << input;
-    }
-};
-
-// Write out one row of output
-template<class Converter>
-struct serialize {
-    std::ostream& out;
-    Converter converter;
-    template<class T, class... Ts>
-    void operator()(T&& input1, Ts&&... inputs) {
-        // First value is printed without trailing comma
-        out << "(" << input1;
-        // Remaining values are printed with prefix of a comma
-        CartesianProduct::Detail::for_each(std::forward_as_tuple(inputs...), print_input{out});
-        out << ") => " << converter(input1, inputs...) << '\n';
-    }
-};
-} // namespace Detail
-
-template<class Converter, class Container, class... Containers>
-void verifyAllCombinations(const Reporter& reporter, Converter&& converter, const Container& input0, const Containers&... inputs)
+namespace ApprovalTests
 {
-    std::stringstream s;
-    CartesianProduct::cartesian_product(Detail::serialize<Converter>{s, std::forward<Converter>(converter)}, input0, inputs...);
-    Approvals::verify(s.str(), reporter);
-}
+    namespace CombinationApprovals
+    {
+        namespace Detail
+        {
 
-template<class Converter, class... Containers>
-ApprovalTests::Detail::EnableIfNotDerivedFromReporter<Converter>
-verifyAllCombinations(Converter&& converter, const Containers&... inputs)
-{
-    verifyAllCombinations(DefaultReporter(), std::forward<Converter>(converter), inputs...);
-}
+            // Write out second or subsequent input value, with preceding comma and space
+            struct print_input
+            {
+                std::ostream& out;
+                template <class T> void operator()(const T& input)
+                {
+                    out << ", " << input;
+                }
+            };
 
-} // namespace CombinationApprovals
+            // Write out one row of output
+            template <class Converter> struct serialize
+            {
+                std::ostream& out;
+                Converter converter;
+                template <class T, class... Ts>
+                void operator()(T&& input1, Ts&&... inputs)
+                {
+                    // First value is printed without trailing comma
+                    out << "(" << input1;
+                    // Remaining values are printed with prefix of a comma
+                    CartesianProduct::Detail::for_each(
+                        std::forward_as_tuple(inputs...), print_input{out});
+                    out << ") => " << converter(input1, inputs...) << '\n';
+                }
+            };
+        } // namespace Detail
+
+        template <class Converter, class Container, class... Containers>
+        void verifyAllCombinations(const Reporter& reporter,
+                                   Converter&& converter,
+                                   const Container& input0,
+                                   const Containers&... inputs)
+        {
+            std::stringstream s;
+            CartesianProduct::cartesian_product(
+                Detail::serialize<Converter>{
+                    s, std::forward<Converter>(converter)},
+                input0,
+                inputs...);
+            Approvals::verify(s.str(), reporter);
+        }
+
+        template <class Converter, class... Containers>
+        ApprovalTests::Detail::EnableIfNotDerivedFromReporter<Converter>
+        verifyAllCombinations(Converter&& converter,
+                              const Containers&... inputs)
+        {
+            verifyAllCombinations(DefaultReporter(),
+                                  std::forward<Converter>(converter),
+                                  inputs...);
+        }
+
+    } // namespace CombinationApprovals
 } // namespace ApprovalTests
 
 #endif

--- a/ApprovalTests/comparators/ComparatorDisposer.h
+++ b/ApprovalTests/comparators/ComparatorDisposer.h
@@ -9,35 +9,35 @@
 namespace ApprovalTests
 {
 
-using ComparatorContainer = std::map<std::string, std::shared_ptr<ApprovalComparator> >;
+    using ComparatorContainer =
+        std::map<std::string, std::shared_ptr<ApprovalComparator>>;
 
-class APPROVAL_TESTS_NO_DISCARD ComparatorDisposer
-{
-public:
-    ComparatorDisposer(
-            ComparatorContainer &comparators,
+    class APPROVAL_TESTS_NO_DISCARD ComparatorDisposer
+    {
+    public:
+        ComparatorDisposer(
+            ComparatorContainer& comparators,
             std::string extensionWithDot,
-            std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator,
+            std::shared_ptr<ApprovalTests::ApprovalComparator>
+                previousComparator,
             std::shared_ptr<ApprovalTests::ApprovalComparator> newComparator)
-            :
-            comparators(comparators),
-            ext_(extensionWithDot),
-            previousComparator(previousComparator)
-    {
-        comparators[extensionWithDot] = newComparator;
-    }
+            : comparators(comparators)
+            , ext_(extensionWithDot)
+            , previousComparator(previousComparator)
+        {
+            comparators[extensionWithDot] = newComparator;
+        }
 
-    ~ComparatorDisposer()
-    {
-        comparators[ext_] = previousComparator;
-    }
+        ~ComparatorDisposer()
+        {
+            comparators[ext_] = previousComparator;
+        }
 
-private:
-    ComparatorContainer &comparators;
-    std::string ext_;
-    std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator;
-};
-
+    private:
+        ComparatorContainer& comparators;
+        std::string ext_;
+        std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator;
+    };
 }
 
 #endif //APPROVALTESTS_CPP_COMPARATORDISPOSER_H

--- a/ApprovalTests/comparators/ComparatorFactory.h
+++ b/ApprovalTests/comparators/ComparatorFactory.h
@@ -7,38 +7,50 @@
 #include "ApprovalTests/comparators/ComparatorDisposer.h"
 #include "ApprovalTests/utilities/FileUtils.h"
 
-namespace ApprovalTests {
+namespace ApprovalTests
+{
 
-class ComparatorFactory {
-private:
-    static ComparatorContainer &comparators() {
-        static ComparatorContainer allComparators;
-        return allComparators;
-    }
-
-public:
-    static ComparatorDisposer
-    registerComparator(const std::string &extensionWithDot, std::shared_ptr<ApprovalComparator> comparator) {
-        return ComparatorDisposer(comparators(), extensionWithDot,
-                                  getComparatorForFileExtensionWithDot(extensionWithDot),
-                                  comparator);
-    }
-
-    static std::shared_ptr<ApprovalComparator> getComparatorForFile(const std::string &receivedPath) {
-        const std::string fileExtension = FileUtils::getExtensionWithDot(receivedPath);
-        return getComparatorForFileExtensionWithDot(fileExtension);
-    }
-
-    static std::shared_ptr<ApprovalComparator>
-    getComparatorForFileExtensionWithDot(const std::string &fileExtensionWithDot) {
-        auto iterator = comparators().find(fileExtensionWithDot);
-        if (iterator != comparators().end()) {
-            return iterator->second;
+    class ComparatorFactory
+    {
+    private:
+        static ComparatorContainer& comparators()
+        {
+            static ComparatorContainer allComparators;
+            return allComparators;
         }
-        return std::make_shared<TextFileComparator>();
-    }
-};
 
+    public:
+        static ComparatorDisposer
+        registerComparator(const std::string& extensionWithDot,
+                           std::shared_ptr<ApprovalComparator> comparator)
+        {
+            return ComparatorDisposer(
+                comparators(),
+                extensionWithDot,
+                getComparatorForFileExtensionWithDot(extensionWithDot),
+                comparator);
+        }
+
+        static std::shared_ptr<ApprovalComparator>
+        getComparatorForFile(const std::string& receivedPath)
+        {
+            const std::string fileExtension =
+                FileUtils::getExtensionWithDot(receivedPath);
+            return getComparatorForFileExtensionWithDot(fileExtension);
+        }
+
+        static std::shared_ptr<ApprovalComparator>
+        getComparatorForFileExtensionWithDot(
+            const std::string& fileExtensionWithDot)
+        {
+            auto iterator = comparators().find(fileExtensionWithDot);
+            if (iterator != comparators().end())
+            {
+                return iterator->second;
+            }
+            return std::make_shared<TextFileComparator>();
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_COMPARATORFACTORY_H

--- a/ApprovalTests/comparators/TextFileComparator.h
+++ b/ApprovalTests/comparators/TextFileComparator.h
@@ -3,41 +3,46 @@
 
 #include "ApprovalTests/core/ApprovalComparator.h"
 
-namespace ApprovalTests {
-class TextFileComparator : public ApprovalComparator
+namespace ApprovalTests
 {
-public:
-    static std::ifstream::int_type getNextRelevantCharacter(std::ifstream& astream)
+    class TextFileComparator : public ApprovalComparator
     {
-        auto ch = astream.get();
-        if (ch == '\r')
+    public:
+        static std::ifstream::int_type
+        getNextRelevantCharacter(std::ifstream& astream)
         {
-            return astream.get();
-        }
-        else
-        {
-            return ch;
-        }
-    }
-
-    virtual bool contentsAreEquivalent(std::string receivedPath,
-                                       std::string approvedPath) const override
-    {
-        std::ifstream astream(approvedPath.c_str(),
-                              std::ios::binary | std::ifstream::in);
-        std::ifstream rstream(receivedPath.c_str(),
-                              std::ios::binary | std::ifstream::in);
-
-        while (astream.good() && rstream.good()) {
-            int a = getNextRelevantCharacter(astream);
-            int r = getNextRelevantCharacter(rstream);
-
-            if (a != r) {
-                return false;
+            auto ch = astream.get();
+            if (ch == '\r')
+            {
+                return astream.get();
+            }
+            else
+            {
+                return ch;
             }
         }
-        return true;
-    }
-};
+
+        virtual bool
+        contentsAreEquivalent(std::string receivedPath,
+                              std::string approvedPath) const override
+        {
+            std::ifstream astream(approvedPath.c_str(),
+                                  std::ios::binary | std::ifstream::in);
+            std::ifstream rstream(receivedPath.c_str(),
+                                  std::ios::binary | std::ifstream::in);
+
+            while (astream.good() && rstream.good())
+            {
+                int a = getNextRelevantCharacter(astream);
+                int r = getNextRelevantCharacter(rstream);
+
+                if (a != r)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    };
 }
 #endif //APPROVALTESTS_CPP_TEXTFILECOMPARATOR_H

--- a/ApprovalTests/core/ApprovalComparator.h
+++ b/ApprovalTests/core/ApprovalComparator.h
@@ -3,15 +3,16 @@
 
 #include <string>
 
-namespace ApprovalTests {
-class ApprovalComparator
+namespace ApprovalTests
 {
-public:
-    virtual ~ApprovalComparator() = default;
+    class ApprovalComparator
+    {
+    public:
+        virtual ~ApprovalComparator() = default;
 
-    virtual bool contentsAreEquivalent(std::string receivedPath,
-                                       std::string approvedPath) const = 0;
-};
+        virtual bool contentsAreEquivalent(std::string receivedPath,
+                                           std::string approvedPath) const = 0;
+    };
 }
 
 #endif //APPROVALTESTS_CPP_APPROVALCOMPARATOR_H

--- a/ApprovalTests/core/ApprovalException.h
+++ b/ApprovalTests/core/ApprovalException.h
@@ -5,56 +5,65 @@
 #include <string>
 #include <sstream>
 
-namespace ApprovalTests {
-class ApprovalException : public std::exception
+namespace ApprovalTests
 {
-private:
-    std::string message;
-public:
-    explicit ApprovalException( const std::string& msg ) : message( msg ) {}
+    class ApprovalException : public std::exception
+    {
+    private:
+        std::string message;
 
-    virtual const char *what() const noexcept override
-    {
-        return message.c_str();
-    }
-};
+    public:
+        explicit ApprovalException(const std::string& msg) : message(msg)
+        {
+        }
 
-class ApprovalMismatchException : public ApprovalException
-{
-private:
-    std::string format( const std::string &received, const std::string &approved )
-    {
-        std::stringstream s;
-        s << "Failed Approval: \n"
-          << "Received does not match approved \n"
-          << "Received : \"" << received << "\" \n"
-          << "Approved : \"" << approved << "\"";
-        return s.str();
-    }
-public:
-    ApprovalMismatchException(const std::string& received, const std::string& approved )
-        : ApprovalException( format( received, approved ) )
-    {
-    }
-};
+        virtual const char* what() const noexcept override
+        {
+            return message.c_str();
+        }
+    };
 
-class ApprovalMissingException : public ApprovalException
-{
-private:
-    std::string format( const std::string &file )
+    class ApprovalMismatchException : public ApprovalException
     {
-        std::stringstream s;
-        s << "Failed Approval: \n"
-          << "Approval File Not Found \n"
-          << "File: \"" << file << '"';
-        return s.str();
-    }
-public:
-    ApprovalMissingException(const std::string& /*received*/, const std::string& approved )
-        : ApprovalException( format( approved ) )
+    private:
+        std::string format(const std::string& received,
+                           const std::string& approved)
+        {
+            std::stringstream s;
+            s << "Failed Approval: \n"
+              << "Received does not match approved \n"
+              << "Received : \"" << received << "\" \n"
+              << "Approved : \"" << approved << "\"";
+            return s.str();
+        }
+
+    public:
+        ApprovalMismatchException(const std::string& received,
+                                  const std::string& approved)
+            : ApprovalException(format(received, approved))
+        {
+        }
+    };
+
+    class ApprovalMissingException : public ApprovalException
     {
-    }
-};
+    private:
+        std::string format(const std::string& file)
+        {
+            std::stringstream s;
+            s << "Failed Approval: \n"
+              << "Approval File Not Found \n"
+              << "File: \"" << file << '"';
+            return s.str();
+        }
+
+    public:
+        ApprovalMissingException(const std::string& /*received*/,
+                                 const std::string& approved)
+            : ApprovalException(format(approved))
+        {
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/core/ApprovalNamer.h
+++ b/ApprovalTests/core/ApprovalNamer.h
@@ -3,15 +3,17 @@
 
 #include <string>
 
-namespace ApprovalTests {
-class ApprovalNamer
+namespace ApprovalTests
 {
-public:
-    virtual ~ApprovalNamer() = default;
-    virtual std::string getApprovedFile(std::string extensionWithDot) const = 0;
-    virtual std::string getReceivedFile(std::string extensionWithDot) const = 0;
-
-};
+    class ApprovalNamer
+    {
+    public:
+        virtual ~ApprovalNamer() = default;
+        virtual std::string
+        getApprovedFile(std::string extensionWithDot) const = 0;
+        virtual std::string
+        getReceivedFile(std::string extensionWithDot) const = 0;
+    };
 }
 
 #endif

--- a/ApprovalTests/core/ApprovalWriter.h
+++ b/ApprovalTests/core/ApprovalWriter.h
@@ -1,15 +1,16 @@
 #ifndef APPROVALTESTS_CPP_APPROVALWRITER_H
 #define APPROVALTESTS_CPP_APPROVALWRITER_H
 
-namespace ApprovalTests {
-class ApprovalWriter
+namespace ApprovalTests
 {
-public:
-    virtual ~ApprovalWriter() = default;
-    virtual std::string getFileExtensionWithDot() const = 0;
-    virtual void write(std::string path) const = 0;
-    virtual void cleanUpReceived(std::string receivedPath) const = 0;
-};
+    class ApprovalWriter
+    {
+    public:
+        virtual ~ApprovalWriter() = default;
+        virtual std::string getFileExtensionWithDot() const = 0;
+        virtual void write(std::string path) const = 0;
+        virtual void cleanUpReceived(std::string receivedPath) const = 0;
+    };
 }
 
 #endif //APPROVALTESTS_CPP_APPROVALWRITER_H

--- a/ApprovalTests/core/FileApprover.h
+++ b/ApprovalTests/core/FileApprover.h
@@ -11,69 +11,89 @@
 #include "ApprovalTests/comparators/ComparatorFactory.h"
 #include "ApprovalTests/utilities/FileUtils.h"
 
-namespace ApprovalTests {
+namespace ApprovalTests
+{
 
-class FileApprover {
-
-public:
-    FileApprover() = default;
-
-    ~FileApprover() = default;
-
-    static ComparatorDisposer registerComparatorForExtension(const std::string& extensionWithDot, std::shared_ptr<ApprovalComparator> comparator)
+    class FileApprover
     {
-        return ComparatorFactory::registerComparator(extensionWithDot, comparator);
-    }
 
-    //! This overload is an implementation detail. To add a new comparator, use registerComparator().
-    static void verify(const std::string& receivedPath,
-                       const std::string& approvedPath,
-                       const ApprovalComparator& comparator) {
-        if (!FileUtils::fileExists(approvedPath)) {
-            throw ApprovalMissingException(receivedPath, approvedPath);
-        }
+    public:
+        FileApprover() = default;
 
-        if (!FileUtils::fileExists(receivedPath)) {
-            throw ApprovalMissingException(approvedPath, receivedPath);
-        }
+        ~FileApprover() = default;
 
-        if (!comparator.contentsAreEquivalent(receivedPath, approvedPath)) {
-            throw ApprovalMismatchException(receivedPath, approvedPath);
-        }
-    }
-
-    static void verify(const std::string& receivedPath,
-                       const std::string& approvedPath) {
-        verify(receivedPath, approvedPath, *ComparatorFactory::getComparatorForFile(receivedPath));
-    }
-
-    static void verify(const ApprovalNamer& n, const ApprovalWriter& s, const Reporter& r) {
-        std::string approvedPath = n.getApprovedFile(s.getFileExtensionWithDot());
-        std::string receivedPath = n.getReceivedFile(s.getFileExtensionWithDot());
-        s.write(receivedPath);
-        try
+        static ComparatorDisposer registerComparatorForExtension(
+            const std::string& extensionWithDot,
+            std::shared_ptr<ApprovalComparator> comparator)
         {
-            verify(receivedPath, approvedPath);
-            s.cleanUpReceived(receivedPath);
+            return ComparatorFactory::registerComparator(extensionWithDot,
+                                                         comparator);
         }
-        catch (const ApprovalException&) {
-            reportAfterTryingFrontLoadedReporter(receivedPath, approvedPath, r);
-            throw;
-        }
-    }
 
-    static void
-    reportAfterTryingFrontLoadedReporter(const std::string &receivedPath, const std::string &approvedPath, const Reporter &r)
-    {
-        auto tryFirst = FrontLoadedReporterFactory::getFrontLoadedReporter();
-        if (!tryFirst->report(receivedPath, approvedPath))
+        //! This overload is an implementation detail. To add a new comparator, use registerComparator().
+        static void verify(const std::string& receivedPath,
+                           const std::string& approvedPath,
+                           const ApprovalComparator& comparator)
         {
-            r.report(receivedPath, approvedPath);
+            if (!FileUtils::fileExists(approvedPath))
+            {
+                throw ApprovalMissingException(receivedPath, approvedPath);
+            }
+
+            if (!FileUtils::fileExists(receivedPath))
+            {
+                throw ApprovalMissingException(approvedPath, receivedPath);
+            }
+
+            if (!comparator.contentsAreEquivalent(receivedPath, approvedPath))
+            {
+                throw ApprovalMismatchException(receivedPath, approvedPath);
+            }
         }
-    }
 
+        static void verify(const std::string& receivedPath,
+                           const std::string& approvedPath)
+        {
+            verify(receivedPath,
+                   approvedPath,
+                   *ComparatorFactory::getComparatorForFile(receivedPath));
+        }
 
-};
+        static void verify(const ApprovalNamer& n,
+                           const ApprovalWriter& s,
+                           const Reporter& r)
+        {
+            std::string approvedPath =
+                n.getApprovedFile(s.getFileExtensionWithDot());
+            std::string receivedPath =
+                n.getReceivedFile(s.getFileExtensionWithDot());
+            s.write(receivedPath);
+            try
+            {
+                verify(receivedPath, approvedPath);
+                s.cleanUpReceived(receivedPath);
+            }
+            catch (const ApprovalException&)
+            {
+                reportAfterTryingFrontLoadedReporter(
+                    receivedPath, approvedPath, r);
+                throw;
+            }
+        }
+
+        static void
+        reportAfterTryingFrontLoadedReporter(const std::string& receivedPath,
+                                             const std::string& approvedPath,
+                                             const Reporter& r)
+        {
+            auto tryFirst =
+                FrontLoadedReporterFactory::getFrontLoadedReporter();
+            if (!tryFirst->report(receivedPath, approvedPath))
+            {
+                r.report(receivedPath, approvedPath);
+            }
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/core/Reporter.h
+++ b/ApprovalTests/core/Reporter.h
@@ -3,20 +3,25 @@
 
 #include <string>
 
-namespace ApprovalTests {
-// Reporters are called on test failure
-class Reporter {
-public:
-    virtual ~Reporter() = default;
-    virtual bool report(std::string received, std::string approved) const = 0;
-};
-
-namespace Detail 
+namespace ApprovalTests
 {
-//! Helper to prevent compilation failure when types are wrongly treated as Reporter:
-template<typename T, typename R = void>
-using EnableIfNotDerivedFromReporter = typename std::enable_if<!std::is_base_of<Reporter, typename std::decay<T>::type>::value, R>::type;
-} // namespace Detail
+    // Reporters are called on test failure
+    class Reporter
+    {
+    public:
+        virtual ~Reporter() = default;
+        virtual bool report(std::string received,
+                            std::string approved) const = 0;
+    };
+
+    namespace Detail
+    {
+        //! Helper to prevent compilation failure when types are wrongly treated as Reporter:
+        template <typename T, typename R = void>
+        using EnableIfNotDerivedFromReporter = typename std::enable_if<
+            !std::is_base_of<Reporter, typename std::decay<T>::type>::value,
+            R>::type;
+    } // namespace Detail
 }
 
 #endif

--- a/ApprovalTests/integrations/catch/Catch2Approvals.h
+++ b/ApprovalTests/integrations/catch/Catch2Approvals.h
@@ -6,36 +6,45 @@
 
 // <SingleHpp unalterable>
 #if defined(APPROVALS_CATCH_EXISTING_MAIN)
-    #define APPROVALS_CATCH
-    #define CATCH_CONFIG_RUNNER
+#define APPROVALS_CATCH
+#define CATCH_CONFIG_RUNNER
 #elif defined(APPROVALS_CATCH)
-    #define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_MAIN
 #endif
 
 #ifdef APPROVALS_CATCH
 #include <catch2/catch.hpp>
 
 //namespace ApprovalTests {
-struct Catch2ApprovalListener : Catch::TestEventListenerBase {
+struct Catch2ApprovalListener : Catch::TestEventListenerBase
+{
     ApprovalTests::TestName currentTest;
-    using TestEventListenerBase::TestEventListenerBase; // This using allows us to use all base-class constructors
-    virtual void testCaseStarting(Catch::TestCaseInfo const &testInfo) override {
+    using TestEventListenerBase::
+        TestEventListenerBase; // This using allows us to use all base-class constructors
+    virtual void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
+    {
 
         currentTest.setFileName(testInfo.lineInfo.file);
         ApprovalTests::ApprovalTestNamer::currentTest(&currentTest);
     }
 
-    virtual void testCaseEnded(Catch::TestCaseStats const &/*testCaseStats*/) override {
-        while (!currentTest.sections.empty()) {
+    virtual void
+    testCaseEnded(Catch::TestCaseStats const& /*testCaseStats*/) override
+    {
+        while (!currentTest.sections.empty())
+        {
             currentTest.sections.pop_back();
         }
     }
 
-    virtual void sectionStarting(Catch::SectionInfo const &sectionInfo) override {
+    virtual void sectionStarting(Catch::SectionInfo const& sectionInfo) override
+    {
         currentTest.sections.push_back(sectionInfo.name);
     }
 
-    virtual void sectionEnded(Catch::SectionStats const &/*sectionStats*/) override {
+    virtual void
+    sectionEnded(Catch::SectionStats const& /*sectionStats*/) override
+    {
         currentTest.sections.pop_back();
     }
 };
@@ -46,15 +55,20 @@ CATCH_REGISTER_LISTENER(Catch2ApprovalListener)
 #ifdef TEST_COMMIT_REVERT_CATCH
 
 //namespace ApprovalTests {
-struct Catch2TestCommitRevert : Catch::TestEventListenerBase {
-    using TestEventListenerBase::TestEventListenerBase; // This using allows us to use all base-class constructors
-    virtual void  testRunEnded( Catch::TestRunStats const& testRunStats )override{
+struct Catch2TestCommitRevert : Catch::TestEventListenerBase
+{
+    using TestEventListenerBase::
+        TestEventListenerBase; // This using allows us to use all base-class constructors
+    virtual void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    {
         bool commit = testRunStats.totals.testCases.allOk();
         std::string message = "r ";
-        if (commit) {
+        if (commit)
+        {
             std::cout << "git add -A \n";
             std::cout << "git commit -m " << message;
-        } else
+        }
+        else
         {
             std::cout << "git clean -fd \n";
             std::cout << "git reset --hard HEAD \n";

--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -10,87 +10,126 @@
 
 #include <doctest.h>
 
-namespace ApprovalTests {
-// anonymous namespace to prevent compiler -Wsubobject-linkage warnings
-// This is OK as this code is only compiled on main()
-namespace {
-    struct AbstractReporter : doctest::IReporter {
-        virtual void report_query(const doctest::QueryData&) override {}
-        // called when the whole test run starts
-        virtual void test_run_start() override {}
+namespace ApprovalTests
+{
+    // anonymous namespace to prevent compiler -Wsubobject-linkage warnings
+    // This is OK as this code is only compiled on main()
+    namespace
+    {
+        struct AbstractReporter : doctest::IReporter
+        {
+            virtual void report_query(const doctest::QueryData&) override
+            {
+            }
+            // called when the whole test run starts
+            virtual void test_run_start() override
+            {
+            }
 
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const doctest::TestRunStats &) override {}
+            // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+            virtual void test_run_end(const doctest::TestRunStats&) override
+            {
+            }
 
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const doctest::TestCaseData &) override {}
+            // called when a test case is started (safe to cache a pointer to the input)
+            virtual void test_case_start(const doctest::TestCaseData&) override
+            {
+            }
 
 #if 20305 <= DOCTEST_VERSION
-        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const doctest::TestCaseData&) override {}
+            // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+            virtual void
+            test_case_reenter(const doctest::TestCaseData&) override
+            {
+            }
 #endif
 
-        // called when a test case has ended
-        virtual void test_case_end(const doctest::CurrentTestCaseStats &) override {}
+            // called when a test case has ended
+            virtual void
+            test_case_end(const doctest::CurrentTestCaseStats&) override
+            {
+            }
 
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const doctest::TestCaseException &) override {}
+            // called when an exception is thrown from the test case (or it crashes)
+            virtual void
+            test_case_exception(const doctest::TestCaseException&) override
+            {
+            }
 
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const doctest::SubcaseSignature &) override {}
+            // called whenever a subcase is entered (don't cache pointers to the input)
+            virtual void
+            subcase_start(const doctest::SubcaseSignature&) override
+            {
+            }
 
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() override {}
+            // called whenever a subcase is exited (don't cache pointers to the input)
+            virtual void subcase_end() override
+            {
+            }
 
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const doctest::AssertData &) override {}
+            // called for each assert (don't cache pointers to the input)
+            virtual void log_assert(const doctest::AssertData&) override
+            {
+            }
 
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const doctest::MessageData &) override {}
+            // called for each message (don't cache pointers to the input)
+            virtual void log_message(const doctest::MessageData&) override
+            {
+            }
 
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const doctest::TestCaseData &) override {}
+            // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
+            // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
+            virtual void
+            test_case_skipped(const doctest::TestCaseData&) override
+            {
+            }
+        };
 
+        struct DocTestApprovalListener : AbstractReporter
+        {
+            TestName currentTest;
 
-    };
+            // constructor has to accept the ContextOptions by ref as a single argument
+            explicit DocTestApprovalListener(
+                const doctest::ContextOptions& /*in*/)
+            {
+            }
 
-    struct DocTestApprovalListener : AbstractReporter {
-        TestName currentTest;
+            void test_case_start(const doctest::TestCaseData& testInfo) override
+            {
 
-        // constructor has to accept the ContextOptions by ref as a single argument
-        explicit DocTestApprovalListener(const doctest::ContextOptions & /*in*/) {
-        }
+                currentTest.sections.emplace_back(testInfo.m_name);
+                currentTest.setFileName(testInfo.m_file);
+                ApprovalTestNamer::currentTest(&currentTest);
+            }
 
-        void test_case_start(const doctest::TestCaseData &testInfo) override {
+            void
+            test_case_end(const doctest::CurrentTestCaseStats& /*in*/) override
+            {
 
-            currentTest.sections.emplace_back(testInfo.m_name);
-            currentTest.setFileName(testInfo.m_file);
-            ApprovalTestNamer::currentTest(&currentTest);
-        }
+                while (!currentTest.sections.empty())
+                {
+                    currentTest.sections.pop_back();
+                }
+            }
 
-        void test_case_end(const doctest::CurrentTestCaseStats & /*in*/) override {
+            void
+            subcase_start(const doctest::SubcaseSignature& signature) override
+            {
 
-            while (!currentTest.sections.empty()) {
+                currentTest.sections.emplace_back(signature.m_name);
+            }
+
+            void subcase_end() override
+            {
+
                 currentTest.sections.pop_back();
             }
-        }
-
-        void subcase_start(const doctest::SubcaseSignature &signature) override {
-
-            currentTest.sections.emplace_back(signature.m_name);
-        }
-
-        void subcase_end() override {
-
-            currentTest.sections.pop_back();
-        }
-    };
-}
+        };
+    }
 }
 
 REGISTER_LISTENER("approvals", 0, ApprovalTests::DocTestApprovalListener);
-
 
 #endif // APPROVALS_DOCTEST
 // </SingleHpp>

--- a/ApprovalTests/integrations/google/GoogleConfiguration.h
+++ b/ApprovalTests/integrations/google/GoogleConfiguration.h
@@ -3,37 +3,46 @@
 
 #include "GoogleCustomizationsFactory.h"
 
-namespace ApprovalTests {
-class GoogleConfiguration
+namespace ApprovalTests
 {
-public:
-    // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
-    APPROVAL_TESTS_NO_DISCARD static bool addTestCaseNameRedundancyCheck(GoogleCustomizationsFactory::Comparator comparator)
+    class GoogleConfiguration
     {
-        return GoogleCustomizationsFactory::addTestCaseNameRedundancyCheck(comparator);
-    }
-
-    // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
-    APPROVAL_TESTS_NO_DISCARD static bool addIgnorableTestCaseNameSuffix(std::string suffix)
-    {
-        return addTestCaseNameRedundancyCheck( createIgnorableTestCaseNameSuffixCheck(suffix) );
-    }
-
-    static GoogleCustomizationsFactory::Comparator createIgnorableTestCaseNameSuffixCheck( const std::string& suffix )
-    {
-        return [suffix](std::string testFileNameWithExtension, std::string testCaseName)
+    public:
+        // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
+        APPROVAL_TESTS_NO_DISCARD static bool addTestCaseNameRedundancyCheck(
+            GoogleCustomizationsFactory::Comparator comparator)
         {
-            if (testCaseName.length() <= suffix.length() || !StringUtils::endsWith(testCaseName, suffix))
-            {
-                return false;
-            }
+            return GoogleCustomizationsFactory::addTestCaseNameRedundancyCheck(
+                comparator);
+        }
 
-            auto withoutSuffix = testCaseName.substr(0, testCaseName.length() - suffix.length());
-            auto withFileExtension = withoutSuffix + ".";
-            return StringUtils::contains(testFileNameWithExtension, withFileExtension);
-        };
-    }
-};
+        // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
+        APPROVAL_TESTS_NO_DISCARD static bool
+        addIgnorableTestCaseNameSuffix(std::string suffix)
+        {
+            return addTestCaseNameRedundancyCheck(
+                createIgnorableTestCaseNameSuffixCheck(suffix));
+        }
+
+        static GoogleCustomizationsFactory::Comparator
+        createIgnorableTestCaseNameSuffixCheck(const std::string& suffix)
+        {
+            return [suffix](std::string testFileNameWithExtension,
+                            std::string testCaseName) {
+                if (testCaseName.length() <= suffix.length() ||
+                    !StringUtils::endsWith(testCaseName, suffix))
+                {
+                    return false;
+                }
+
+                auto withoutSuffix = testCaseName.substr(
+                    0, testCaseName.length() - suffix.length());
+                auto withFileExtension = withoutSuffix + ".";
+                return StringUtils::contains(testFileNameWithExtension,
+                                             withFileExtension);
+            };
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_GOOGLECONFIGURATION_H

--- a/ApprovalTests/integrations/google/GoogleCustomizationsFactory.h
+++ b/ApprovalTests/integrations/google/GoogleCustomizationsFactory.h
@@ -7,41 +7,45 @@
 #include <functional>
 #include <string>
 
-namespace ApprovalTests {
-class GoogleCustomizationsFactory
+namespace ApprovalTests
 {
-public:
-    using Comparator = std::function<bool(const std::string&, const std::string&)>;
-private:
-    using ComparatorContainer = std::vector< Comparator >;
-    static ComparatorContainer& comparatorContainer()
+    class GoogleCustomizationsFactory
     {
-        static ComparatorContainer container;
-        if (container.empty())
+    public:
+        using Comparator =
+            std::function<bool(const std::string&, const std::string&)>;
+
+    private:
+        using ComparatorContainer = std::vector<Comparator>;
+        static ComparatorContainer& comparatorContainer()
         {
-            auto exactNameMatching = [](const std::string& testFileNameWithExtension, const std::string& testCaseName)
+            static ComparatorContainer container;
+            if (container.empty())
             {
-                return StringUtils::contains(testFileNameWithExtension, testCaseName + ".");
-            };
-            container.push_back( exactNameMatching );
+                auto exactNameMatching =
+                    [](const std::string& testFileNameWithExtension,
+                       const std::string& testCaseName) {
+                        return StringUtils::contains(testFileNameWithExtension,
+                                                     testCaseName + ".");
+                    };
+                container.push_back(exactNameMatching);
+            }
+            return container;
         }
-        return container;
-    }
 
-public:
-    static ComparatorContainer getEquivalencyChecks()
-    {
-        return comparatorContainer();
-    }
+    public:
+        static ComparatorContainer getEquivalencyChecks()
+        {
+            return comparatorContainer();
+        }
 
-    APPROVAL_TESTS_NO_DISCARD static bool addTestCaseNameRedundancyCheck(const Comparator& comparator)
-    {
-        comparatorContainer().push_back(comparator);
-        return true;
-    }
-    
-
-};
+        APPROVAL_TESTS_NO_DISCARD static bool
+        addTestCaseNameRedundancyCheck(const Comparator& comparator)
+        {
+            comparatorContainer().push_back(comparator);
+            return true;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_GOOGLECUSTOMIZATIONSFACTORY_H

--- a/ApprovalTests/integrations/google/GoogleTestApprovals.h
+++ b/ApprovalTests/integrations/google/GoogleTestApprovals.h
@@ -14,44 +14,50 @@
 // <SingleHpp unalterable>
 #include "gtest/gtest.h"
 
-namespace ApprovalTests {
-class GoogleTestListener : public testing::EmptyTestEventListener
+namespace ApprovalTests
 {
-    TestName currentTest;
-public:
-    bool isDuplicate(std::string testFileNameWithExtension, std::string testCaseName)
+    class GoogleTestListener : public testing::EmptyTestEventListener
     {
-        for( auto check : GoogleCustomizationsFactory::getEquivalencyChecks())
+        TestName currentTest;
+
+    public:
+        bool isDuplicate(std::string testFileNameWithExtension,
+                         std::string testCaseName)
         {
-            if (check(testFileNameWithExtension, testCaseName))
+            for (auto check :
+                 GoogleCustomizationsFactory::getEquivalencyChecks())
             {
-                return true;
+                if (check(testFileNameWithExtension, testCaseName))
+                {
+                    return true;
+                }
             }
+            return false;
         }
-        return false;
-    }
 
-    virtual void OnTestStart(const testing::TestInfo& testInfo) override
+        virtual void OnTestStart(const testing::TestInfo& testInfo) override
+        {
+            currentTest.setFileName(testInfo.file());
+            currentTest.sections = {};
+            if (!isDuplicate(currentTest.getFileName(),
+                             testInfo.test_case_name()))
+            {
+                currentTest.sections.emplace_back(testInfo.test_case_name());
+            }
+            if (!std::string(testInfo.name()).empty())
+            {
+                currentTest.sections.emplace_back(testInfo.name());
+            }
+
+            ApprovalTestNamer::currentTest(&currentTest);
+        }
+    };
+
+    inline void initializeApprovalTestsForGoogleTests()
     {
-        currentTest.setFileName(testInfo.file());
-        currentTest.sections = {};
-        if (! isDuplicate(currentTest.getFileName(), testInfo.test_case_name()))
-        {
-            currentTest.sections.emplace_back(testInfo.test_case_name());
-        }
-        if (! std::string(testInfo.name()).empty())
-        {
-            currentTest.sections.emplace_back(testInfo.name());
-        }
-        
-        ApprovalTestNamer::currentTest(&currentTest);
+        auto& listeners = testing::UnitTest::GetInstance()->listeners();
+        listeners.Append(new GoogleTestListener);
     }
-};
-
-inline void initializeApprovalTestsForGoogleTests() {
-    auto& listeners = testing::UnitTest::GetInstance()->listeners();
-    listeners.Append(new GoogleTestListener);
-}
 }
 
 #ifndef APPROVALS_GOOGLETEST_EXISTING_MAIN

--- a/ApprovalTests/integrations/ut/UTApprovals.h
+++ b/ApprovalTests/integrations/ut/UTApprovals.h
@@ -7,76 +7,91 @@
 #ifdef APPROVALS_UT
 
 #if !(__GNUC__ >= 9 or __clang_major__ >= 9)
-#error "The [Boost].UT integration with Approval Tests requires source_location support by the compiler"
+#error                                                                         \
+    "The [Boost].UT integration with Approval Tests requires source_location support by the compiler"
 #endif
 
 #include <boost/ut.hpp>
 
 namespace ApprovalTests
 {
-    namespace cfg {
-        class reporter : public boost::ut::reporter<boost::ut::printer> {
-            private:
-                TestName currentTest;
+    namespace cfg
+    {
+        class reporter : public boost::ut::reporter<boost::ut::printer>
+        {
+        private:
+            TestName currentTest;
 
-            public:
-                auto on(boost::ut::events::test_begin test_begin) -> void {
-                    std::string name = test_begin.name;
-                    currentTest.sections.emplace_back(name);
-                    currentTest.setFileName(test_begin.location.file_name());
+        public:
+            auto on(boost::ut::events::test_begin test_begin) -> void
+            {
+                std::string name = test_begin.name;
+                currentTest.sections.emplace_back(name);
+                currentTest.setFileName(test_begin.location.file_name());
 
-                    ApprovalTestNamer::currentTest(&currentTest);
+                ApprovalTestNamer::currentTest(&currentTest);
 
-                    boost::ut::reporter<boost::ut::printer>::on(test_begin);
+                boost::ut::reporter<boost::ut::printer>::on(test_begin);
+            }
+
+            auto on(boost::ut::events::test_run test_run) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(test_run);
+            }
+
+            auto on(boost::ut::events::test_skip test_skip) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(test_skip);
+            }
+
+            auto on(boost::ut::events::test_end test_end) -> void
+            {
+                while (!currentTest.sections.empty())
+                {
+                    currentTest.sections.pop_back();
                 }
+                boost::ut::reporter<boost::ut::printer>::on(test_end);
+            }
 
-                auto on(boost::ut::events::test_run test_run) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(test_run);
-                }
+            template <class TMsg>
+            auto on(boost::ut::events::log<TMsg> log) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(log);
+            }
 
-                auto on(boost::ut::events::test_skip test_skip) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(test_skip);
-                }
+            template <class TExpr>
+            auto on(boost::ut::events::assertion_pass<TExpr> location) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(location);
+            }
 
-                auto on(boost::ut::events::test_end test_end) -> void {
-                    while (!currentTest.sections.empty()) {
-                        currentTest.sections.pop_back();
-                    }
-                    boost::ut::reporter<boost::ut::printer>::on(test_end);
-                }
+            template <class TExpr>
+            auto on(boost::ut::events::assertion_fail<TExpr> fail) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(fail);
+            }
 
-                template <class TMsg>
-                auto on(boost::ut::events::log<TMsg> log) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(log);
-                }
+            auto on(boost::ut::events::fatal_assertion fatal) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(fatal);
+            }
 
-                template <class TExpr>
-                auto on(boost::ut::events::assertion_pass<TExpr> location) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(location);
-                }
+            auto on(boost::ut::events::exception exception) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(exception);
+            }
 
-                template <class TExpr>
-                auto on(boost::ut::events::assertion_fail<TExpr> fail) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(fail);
-                }
-
-                auto on(boost::ut::events::fatal_assertion fatal) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(fatal);
-                }
-
-                auto on(boost::ut::events::exception exception) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(exception);
-                }
-
-                auto on(boost::ut::events::summary summary) -> void {
-                    boost::ut::reporter<boost::ut::printer>::on(summary);
-                }
+            auto on(boost::ut::events::summary summary) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(summary);
+            }
         };
-    }  // namespace cfg
+    } // namespace cfg
 }
 
 template <>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<ApprovalTests::cfg::reporter>{};
+auto boost::ut::cfg<boost::ut::override> =
+    boost::ut::runner<ApprovalTests::cfg::reporter>{};
 
 #endif // APPROVALS_UT
 // </SingleHpp>

--- a/ApprovalTests/launchers/CommandLauncher.h
+++ b/ApprovalTests/launchers/CommandLauncher.h
@@ -4,14 +4,15 @@
 #include <string>
 #include <vector>
 
-namespace ApprovalTests {
-// An interface to trigger execution of a command. See also SystemLauncher
-class CommandLauncher
+namespace ApprovalTests
 {
-public:
-    virtual ~CommandLauncher() = default;
-    virtual bool launch(std::vector<std::string> argv) = 0;
-};
+    // An interface to trigger execution of a command. See also SystemLauncher
+    class CommandLauncher
+    {
+    public:
+        virtual ~CommandLauncher() = default;
+        virtual bool launch(std::vector<std::string> argv) = 0;
+    };
 }
 
-#endif  
+#endif

--- a/ApprovalTests/launchers/SystemLauncher.h
+++ b/ApprovalTests/launchers/SystemLauncher.h
@@ -10,60 +10,74 @@
 #include <numeric>
 #include "CommandLauncher.h"
 
-namespace ApprovalTests {
-    using ConvertArgumentsFunctionPointer = std::vector<std::string>(*)(std::vector<std::string>);
-
-class SystemLauncher : public CommandLauncher
+namespace ApprovalTests
 {
-private:
-    ConvertArgumentsFunctionPointer convertArgumentsForSystemLaunching;
-public:
-    SystemLauncher() : SystemLauncher(doNothing)
-    {
-    }
+    using ConvertArgumentsFunctionPointer =
+        std::vector<std::string> (*)(std::vector<std::string>);
 
-    explicit SystemLauncher(std::vector<std::string> (*pointer)(std::vector<std::string>)) : convertArgumentsForSystemLaunching(pointer) 
+    class SystemLauncher : public CommandLauncher
     {
-    }
+    private:
+        ConvertArgumentsFunctionPointer convertArgumentsForSystemLaunching;
 
-    // This function is an implementation detail for the support of Reporters on cygwin
-    void setConvertArgumentsForSystemLaunchingFunction(ConvertArgumentsFunctionPointer function)
-    {
-        convertArgumentsForSystemLaunching = function;
-    }
-
-    bool exists(const std::string& command)
-    {
-        bool foundByWhich = false;
-        if (!SystemUtils::isWindowsOs()) {
-            std::string which = "which " + command + " > /dev/null 2>&1";
-            int result = system(which.c_str());
-            foundByWhich = (result == 0);
-        }
-        return  foundByWhich || FileUtils::fileExists(command);
-
-    }
-
-    static std::vector<std::string> doNothing(std::vector<std::string> argv)
-    {
-        return argv;
-    }
-
-    bool launch(std::vector<std::string> argv) override
-    {
-        if (!exists(argv.front()))
+    public:
+        SystemLauncher() : SystemLauncher(doNothing)
         {
-            return false;
         }
 
-        argv = convertArgumentsForSystemLaunching(argv);
+        explicit SystemLauncher(
+            std::vector<std::string> (*pointer)(std::vector<std::string>))
+            : convertArgumentsForSystemLaunching(pointer)
+        {
+        }
 
-        std::string command = std::accumulate(argv.begin(), argv.end(), std::string(""), [](const std::string& a, const std::string& b) {return a + " " + "\"" + b + "\""; });
-        std::string launch = SystemUtils::isWindowsOs() ? ("start \"\" " + command) : (command + " &");
-        system(launch.c_str());
-        return true;
-    }
-};
+        // This function is an implementation detail for the support of Reporters on cygwin
+        void setConvertArgumentsForSystemLaunchingFunction(
+            ConvertArgumentsFunctionPointer function)
+        {
+            convertArgumentsForSystemLaunching = function;
+        }
+
+        bool exists(const std::string& command)
+        {
+            bool foundByWhich = false;
+            if (!SystemUtils::isWindowsOs())
+            {
+                std::string which = "which " + command + " > /dev/null 2>&1";
+                int result = system(which.c_str());
+                foundByWhich = (result == 0);
+            }
+            return foundByWhich || FileUtils::fileExists(command);
+        }
+
+        static std::vector<std::string> doNothing(std::vector<std::string> argv)
+        {
+            return argv;
+        }
+
+        bool launch(std::vector<std::string> argv) override
+        {
+            if (!exists(argv.front()))
+            {
+                return false;
+            }
+
+            argv = convertArgumentsForSystemLaunching(argv);
+
+            std::string command =
+                std::accumulate(argv.begin(),
+                                argv.end(),
+                                std::string(""),
+                                [](const std::string& a, const std::string& b) {
+                                    return a + " " + "\"" + b + "\"";
+                                });
+            std::string launch = SystemUtils::isWindowsOs()
+                                     ? ("start \"\" " + command)
+                                     : (command + " &");
+            system(launch.c_str());
+            return true;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_SYSTEMLAUNCHER_H

--- a/ApprovalTests/namers/ApprovalTestNamer.h
+++ b/ApprovalTests/namers/ApprovalTestNamer.h
@@ -9,168 +9,191 @@
 #include "ApprovalTests/utilities/SystemUtils.h"
 #include "ApprovalTests/namers/HelpMessages.h"
 
-namespace ApprovalTests {
-class TestName {
-public:
-    const std::string& getFileName() const {
-        checkBuildConfiguration(fileName);
-        return fileName;
-    }
-
-    void setFileName(const std::string &file) {
-        fileName = SystemUtils::checkFilenameCase(file);
-    }
-
-private:
-    static void checkBuildConfiguration(const std::string& fileName) {
-        if(! FileUtils::fileExists(fileName))
-        {
-            throw std::runtime_error(getMisconfiguredBuildHelp(fileName));
-        }
-    }
-
-public:
-    static std::string getMisconfiguredBuildHelp(const std::string& fileName)
+namespace ApprovalTests
+{
+    class TestName
     {
-        return HelpMessages::getMisconfiguredBuildHelp(fileName);
-    }
-
-    std::vector<std::string> sections;
-private:
-    std::string fileName;
-};
-
-class TestConfiguration {
-public:
-    std::string subdirectory;
-};
-
-class ApprovalTestNamer : public ApprovalNamer {
-private:
-public:
-    ApprovalTestNamer() = default;
-
-    std::string getTestName() const {
-        std::stringstream ext;
-        auto test = getCurrentTest();
-        for (size_t i = 0; i < test.sections.size(); i++) {
-            if (0 < i) {
-                ext << ".";
-            }
-            ext << test.sections[i];
+    public:
+        const std::string& getFileName() const
+        {
+            checkBuildConfiguration(fileName);
+            return fileName;
         }
 
-        return convertToFileName(ext.str());
-    }
-
-    static bool isForbidden(char c)
-    {
-        static std::string forbiddenChars("\\/:?\"<>|' ");
-        return std::string::npos != forbiddenChars.find(c);
-    }
-
-    static std::string convertToFileName(const std::string& fileName)
-    {
-        std::stringstream result;
-        for (auto ch : fileName)
+        void setFileName(const std::string& file)
         {
-            if (!isForbidden(ch))
+            fileName = SystemUtils::checkFilenameCase(file);
+        }
+
+    private:
+        static void checkBuildConfiguration(const std::string& fileName)
+        {
+            if (!FileUtils::fileExists(fileName))
             {
-                result << ch;
+                throw std::runtime_error(getMisconfiguredBuildHelp(fileName));
             }
-            else
+        }
+
+    public:
+        static std::string
+        getMisconfiguredBuildHelp(const std::string& fileName)
+        {
+            return HelpMessages::getMisconfiguredBuildHelp(fileName);
+        }
+
+        std::vector<std::string> sections;
+
+    private:
+        std::string fileName;
+    };
+
+    class TestConfiguration
+    {
+    public:
+        std::string subdirectory;
+    };
+
+    class ApprovalTestNamer : public ApprovalNamer
+    {
+    private:
+    public:
+        ApprovalTestNamer() = default;
+
+        std::string getTestName() const
+        {
+            std::stringstream ext;
+            auto test = getCurrentTest();
+            for (size_t i = 0; i < test.sections.size(); i++)
             {
-                result << "_";
+                if (0 < i)
+                {
+                    ext << ".";
+                }
+                ext << test.sections[i];
+            }
+
+            return convertToFileName(ext.str());
+        }
+
+        static bool isForbidden(char c)
+        {
+            static std::string forbiddenChars("\\/:?\"<>|' ");
+            return std::string::npos != forbiddenChars.find(c);
+        }
+
+        static std::string convertToFileName(const std::string& fileName)
+        {
+            std::stringstream result;
+            for (auto ch : fileName)
+            {
+                if (!isForbidden(ch))
+                {
+                    result << ch;
+                }
+                else
+                {
+                    result << "_";
+                }
+            }
+            return result.str();
+        }
+
+        static TestName& getCurrentTest()
+        {
+            try
+            {
+                return currentTest();
+            }
+            catch (const std::runtime_error&)
+            {
+                std::string helpMessage = getMisconfiguredMainHelp();
+                throw std::runtime_error(helpMessage);
             }
         }
-        return result.str();
-    }
 
-    static TestName &getCurrentTest()
-    {
-        try
+        static std::string getMisconfiguredMainHelp()
         {
-            return currentTest();
+            return HelpMessages::getMisconfiguredMainHelp();
         }
-        catch( const std::runtime_error& )
+
+        // Deprecated - please use getSourceFileName
+        std::string getFileName() const
         {
-            std::string helpMessage = getMisconfiguredMainHelp();
-            throw std::runtime_error( helpMessage );
+            return getSourceFileName();
         }
-    }
 
-    static std::string getMisconfiguredMainHelp()
-    {
-        return HelpMessages::getMisconfiguredMainHelp();
-    }
-
-
-    // Deprecated - please use getSourceFileName
-    std::string getFileName() const {
-        return getSourceFileName();
-    }
-
-
-    std::string getSourceFileName() const {
-        auto file = getCurrentTest().getFileName();
-        auto start = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
-        auto end = file.rfind('.');
-        auto fileName = file.substr(start, end - start);
-        return convertToFileName(fileName);
-    }
-
-    std::string getDirectory() const {
-        auto file = getCurrentTest().getFileName();
-        auto end = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
-        auto directory = file.substr(0, end);
-        if ( ! testConfiguration().subdirectory.empty() )
+        std::string getSourceFileName() const
         {
-            directory += testConfiguration().subdirectory + SystemUtils::getDirectorySeparator();
-            SystemUtils::ensureDirectoryExists(directory);
+            auto file = getCurrentTest().getFileName();
+            auto start = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
+            auto end = file.rfind('.');
+            auto fileName = file.substr(start, end - start);
+            return convertToFileName(fileName);
         }
-        return directory;
-    }
 
-    static TestName& currentTest(TestName* value = nullptr)
-    {
-        static TestName* staticValue;
-        if (value != nullptr)
+        std::string getDirectory() const
         {
-            staticValue = value;
+            auto file = getCurrentTest().getFileName();
+            auto end = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
+            auto directory = file.substr(0, end);
+            if (!testConfiguration().subdirectory.empty())
+            {
+                directory += testConfiguration().subdirectory +
+                             SystemUtils::getDirectorySeparator();
+                SystemUtils::ensureDirectoryExists(directory);
+            }
+            return directory;
         }
-        if ( staticValue == nullptr )
+
+        static TestName& currentTest(TestName* value = nullptr)
         {
-            throw std::runtime_error("The variable in currentTest() is not initialised");
+            static TestName* staticValue;
+            if (value != nullptr)
+            {
+                staticValue = value;
+            }
+            if (staticValue == nullptr)
+            {
+                throw std::runtime_error(
+                    "The variable in currentTest() is not initialised");
+            }
+            return *staticValue;
         }
-        return *staticValue;
-    }
 
-    static TestConfiguration& testConfiguration()
-    {
-        static TestConfiguration configuration;
-        return configuration;
-    }
+        static TestConfiguration& testConfiguration()
+        {
+            static TestConfiguration configuration;
+            return configuration;
+        }
 
-    virtual std::string getApprovedFile(std::string extensionWithDot) const override {
+        virtual std::string
+        getApprovedFile(std::string extensionWithDot) const override
+        {
 
-        return getFullFileName(".approved", extensionWithDot);
-    }
+            return getFullFileName(".approved", extensionWithDot);
+        }
 
-    virtual std::string getReceivedFile(std::string extensionWithDot) const override {
+        virtual std::string
+        getReceivedFile(std::string extensionWithDot) const override
+        {
 
-        return getFullFileName(".received", extensionWithDot);
-    }
+            return getFullFileName(".received", extensionWithDot);
+        }
 
-    std::string getOutputFileBaseName() const {
-        return getSourceFileName() + "." + getTestName();
-    }
+        std::string getOutputFileBaseName() const
+        {
+            return getSourceFileName() + "." + getTestName();
+        }
 
-    std::string getFullFileName(const std::string& approved, const std::string& extensionWithDot) const {
-        std::stringstream ext;
-        ext << getDirectory() << getOutputFileBaseName() << approved << extensionWithDot;
-        return ext.str();
-    }
-};
+        std::string getFullFileName(const std::string& approved,
+                                    const std::string& extensionWithDot) const
+        {
+            std::stringstream ext;
+            ext << getDirectory() << getOutputFileBaseName() << approved
+                << extensionWithDot;
+            return ext.str();
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/namers/DefaultNamerDisposer.h
+++ b/ApprovalTests/namers/DefaultNamerDisposer.h
@@ -5,24 +5,26 @@
 #include "DefaultNamerFactory.h"
 #include "ApprovalTests/utilities/Macros.h"
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useAsDefaultNamer()
-class APPROVAL_TESTS_NO_DISCARD DefaultNamerDisposer
+namespace ApprovalTests
 {
-private:
-    NamerCreator previous_result;
-public:
-    explicit DefaultNamerDisposer(NamerCreator namerCreator)
+    //! Implementation detail of Approvals::useAsDefaultNamer()
+    class APPROVAL_TESTS_NO_DISCARD DefaultNamerDisposer
     {
-        previous_result = DefaultNamerFactory::getDefaultNamer();
-        DefaultNamerFactory::setDefaultNamer(std::move(namerCreator));
-    }
+    private:
+        NamerCreator previous_result;
 
-    ~DefaultNamerDisposer()
-    {
-        DefaultNamerFactory::setDefaultNamer(previous_result);
-    }
-};
+    public:
+        explicit DefaultNamerDisposer(NamerCreator namerCreator)
+        {
+            previous_result = DefaultNamerFactory::getDefaultNamer();
+            DefaultNamerFactory::setDefaultNamer(std::move(namerCreator));
+        }
+
+        ~DefaultNamerDisposer()
+        {
+            DefaultNamerFactory::setDefaultNamer(previous_result);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTNAMERDISPOSER_H

--- a/ApprovalTests/namers/DefaultNamerFactory.h
+++ b/ApprovalTests/namers/DefaultNamerFactory.h
@@ -7,32 +7,34 @@
 #include <memory>
 #include <utility>
 
-namespace ApprovalTests {
+namespace ApprovalTests
+{
 
     using NamerCreator = std::function<std::shared_ptr<ApprovalNamer>()>;
 
-//! Implementation detail of Approvals::useAsDefaultNamer()
-class DefaultNamerFactory
-{
-private:
-    static NamerCreator& defaultNamer()
+    //! Implementation detail of Approvals::useAsDefaultNamer()
+    class DefaultNamerFactory
     {
-        static NamerCreator namer = [](){return std::make_shared<ApprovalTestNamer>();};
-        return namer;
-    }
+    private:
+        static NamerCreator& defaultNamer()
+        {
+            static NamerCreator namer = []() {
+                return std::make_shared<ApprovalTestNamer>();
+            };
+            return namer;
+        }
 
-public:
-    static NamerCreator getDefaultNamer()
-    {
-        return defaultNamer();
-    }
-    
-    static void setDefaultNamer( NamerCreator namer)
-    {
-        defaultNamer() = std::move(namer);
-    }
+    public:
+        static NamerCreator getDefaultNamer()
+        {
+            return defaultNamer();
+        }
 
-};
+        static void setDefaultNamer(NamerCreator namer)
+        {
+            defaultNamer() = std::move(namer);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTNAMERFACTORY_H

--- a/ApprovalTests/namers/ExistingFileNamer.h
+++ b/ApprovalTests/namers/ExistingFileNamer.h
@@ -5,21 +5,29 @@
 #include "ApprovalTests/core/ApprovalNamer.h"
 #include "DefaultNamerFactory.h"
 
-namespace ApprovalTests {
-class ExistingFileNamer: public ApprovalNamer{
-    std::string filePath;
-public:
-    explicit ExistingFileNamer(std::string filePath): filePath(std::move(filePath)){
+namespace ApprovalTests
+{
+    class ExistingFileNamer : public ApprovalNamer
+    {
+        std::string filePath;
 
-    }
-    virtual std::string getApprovedFile(std::string extensionWithDot) const override {
-        return DefaultNamerFactory::getDefaultNamer()()->getApprovedFile(extensionWithDot);
-    }
-    virtual std::string getReceivedFile(std::string /*extensionWithDot*/) const override {
-        return filePath;
-    }
-
-};
+    public:
+        explicit ExistingFileNamer(std::string filePath)
+            : filePath(std::move(filePath))
+        {
+        }
+        virtual std::string
+        getApprovedFile(std::string extensionWithDot) const override
+        {
+            return DefaultNamerFactory::getDefaultNamer()()->getApprovedFile(
+                extensionWithDot);
+        }
+        virtual std::string
+            getReceivedFile(std::string /*extensionWithDot*/) const override
+        {
+            return filePath;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_EXISTINGFILENAMER_H

--- a/ApprovalTests/namers/HelpMessages.h
+++ b/ApprovalTests/namers/HelpMessages.h
@@ -5,17 +5,22 @@
 #include "ApprovalTests/utilities/StringUtils.h"
 
 // <SingleHpp unalterable>
-namespace ApprovalTests {
-    class HelpMessages {
+namespace ApprovalTests
+{
+    class HelpMessages
+    {
     public:
-
-        static std::string getMisconfiguredBuildHelp(const std::string& fileName)
+        static std::string
+        getMisconfiguredBuildHelp(const std::string& fileName)
         {
-            std::string lineBreak = "************************************************************************************\n";
-            std::string lineBuffer = "*                                                                                  *\n";
-            std::string helpMessage =
-                    "\n\n" + lineBreak + lineBuffer +
-                    R"(* Welcome to Approval Tests.
+            std::string lineBreak =
+                "**************************************************************"
+                "**********************\n";
+            std::string lineBuffer =
+                "*                                                             "
+                "                     *\n";
+            std::string helpMessage = "\n\n" + lineBreak + lineBuffer +
+                                      R"(* Welcome to Approval Tests.
 *
 * There seems to be a problem with your build configuration.
 * We cannot find the test source file at:
@@ -23,17 +28,19 @@ namespace ApprovalTests {
 *
 * For details on how to fix this, please visit:
 * https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/TroubleshootingMisconfiguredBuild.md
-)" +
-                    lineBuffer + lineBreak + '\n';
+)" + lineBuffer + lineBreak + '\n';
             return StringUtils::replaceAll(helpMessage, "[fileName]", fileName);
         }
         static std::string getMisconfiguredMainHelp()
         {
-            std::string lineBreak = "************************************************************************************\n";
-            std::string lineBuffer = "*                                                                                  *\n";
-            std::string helpMessage =
-                    "\n\n" + lineBreak + lineBuffer +
-                    R"(* Welcome to Approval Tests.
+            std::string lineBreak =
+                "**************************************************************"
+                "**********************\n";
+            std::string lineBuffer =
+                "*                                                             "
+                "                     *\n";
+            std::string helpMessage = "\n\n" + lineBreak + lineBuffer +
+                                      R"(* Welcome to Approval Tests.
 *
 * You have forgotten to configure your test framework for Approval Tests.
 *
@@ -59,8 +66,7 @@ namespace ApprovalTests {
 *
 * For more information, please visit:
 * https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/GettingStarted.md
-)" +
-                    lineBuffer + lineBreak + '\n';
+)" + lineBuffer + lineBreak + '\n';
             return helpMessage;
         }
     };

--- a/ApprovalTests/namers/NamerFactory.h
+++ b/ApprovalTests/namers/NamerFactory.h
@@ -6,14 +6,17 @@
 
 #include <string>
 
-namespace ApprovalTests {
-struct NamerFactory
+namespace ApprovalTests
 {
-    static SectionNameDisposer appendToOutputFilename(const std::string& sectionName)
+    struct NamerFactory
     {
-        return SectionNameDisposer(ApprovalTestNamer::currentTest(), sectionName);
-    }
-};
+        static SectionNameDisposer
+        appendToOutputFilename(const std::string& sectionName)
+        {
+            return SectionNameDisposer(ApprovalTestNamer::currentTest(),
+                                       sectionName);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_NAMERFACTORY_H

--- a/ApprovalTests/namers/SectionNameDisposer.h
+++ b/ApprovalTests/namers/SectionNameDisposer.h
@@ -3,26 +3,29 @@
 
 #include "ApprovalTestNamer.h"
 
-namespace ApprovalTests {
-class APPROVAL_TESTS_NO_DISCARD SectionNameDisposer
+namespace ApprovalTests
 {
-public:
-    SectionNameDisposer(TestName& currentTest, const std::string& scope_name) :
-        currentTest(currentTest)
+    class APPROVAL_TESTS_NO_DISCARD SectionNameDisposer
     {
-        // Add extra section to output filename, to allow multiple files
-        // to verified from a single test:
-        currentTest.sections.push_back(scope_name);
-    }
+    public:
+        SectionNameDisposer(TestName& currentTest,
+                            const std::string& scope_name)
+            : currentTest(currentTest)
+        {
+            // Add extra section to output filename, to allow multiple files
+            // to verified from a single test:
+            currentTest.sections.push_back(scope_name);
+        }
 
-    ~SectionNameDisposer()
-    {
-        // Remove the extra section we added in the constructor
-        currentTest.sections.pop_back();
-    }
-private:
-    TestName& currentTest;
-};
+        ~SectionNameDisposer()
+        {
+            // Remove the extra section we added in the constructor
+            currentTest.sections.pop_back();
+        }
+
+    private:
+        TestName& currentTest;
+    };
 }
 
 #endif //APPROVALTESTS_CPP_SECTIONNAMEDISPOSER_H

--- a/ApprovalTests/namers/SeparateApprovedAndReceivedDirectoriesNamer.h
+++ b/ApprovalTests/namers/SeparateApprovedAndReceivedDirectoriesNamer.h
@@ -4,38 +4,49 @@
 #include "ApprovalTestNamer.h"
 #include "../Approvals.h"
 
-namespace ApprovalTests {
-class SeparateApprovedAndReceivedDirectoriesNamer : public ApprovalTestNamer
+namespace ApprovalTests
 {
-public:
-    virtual ~SeparateApprovedAndReceivedDirectoriesNamer() = default;
+    class SeparateApprovedAndReceivedDirectoriesNamer : public ApprovalTestNamer
+    {
+    public:
+        virtual ~SeparateApprovedAndReceivedDirectoriesNamer() = default;
 
-    std::string getFullFileNameWithExtraDirectory(const std::string& approved, const std::string& extensionWithDot) const
-    {
-        std::string outputDirectory = getDirectory() +  approved;
-        SystemUtils::ensureDirectoryExists(outputDirectory);
-    
-        std::string outputFile = getFileName() + "." + getTestName() + extensionWithDot;
-    
-        return outputDirectory + SystemUtils::getDirectorySeparator() + outputFile;
-    }
-    
-    virtual std::string getApprovedFile(std::string extensionWithDot) const override
-    {
-        return getFullFileNameWithExtraDirectory("approved", extensionWithDot);
-    }
-    
-    virtual std::string getReceivedFile(std::string extensionWithDot) const override
-    {
-        return getFullFileNameWithExtraDirectory("received", extensionWithDot);
-    }
-    
-    static DefaultNamerDisposer useAsDefaultNamer()
-    {
-        return Approvals::useAsDefaultNamer([](){return std::make_shared<SeparateApprovedAndReceivedDirectoriesNamer>();});
-    }
+        std::string getFullFileNameWithExtraDirectory(
+            const std::string& approved,
+            const std::string& extensionWithDot) const
+        {
+            std::string outputDirectory = getDirectory() + approved;
+            SystemUtils::ensureDirectoryExists(outputDirectory);
 
-};
+            std::string outputFile =
+                getFileName() + "." + getTestName() + extensionWithDot;
+
+            return outputDirectory + SystemUtils::getDirectorySeparator() +
+                   outputFile;
+        }
+
+        virtual std::string
+        getApprovedFile(std::string extensionWithDot) const override
+        {
+            return getFullFileNameWithExtraDirectory("approved",
+                                                     extensionWithDot);
+        }
+
+        virtual std::string
+        getReceivedFile(std::string extensionWithDot) const override
+        {
+            return getFullFileNameWithExtraDirectory("received",
+                                                     extensionWithDot);
+        }
+
+        static DefaultNamerDisposer useAsDefaultNamer()
+        {
+            return Approvals::useAsDefaultNamer([]() {
+                return std::make_shared<
+                    SeparateApprovedAndReceivedDirectoriesNamer>();
+            });
+        }
+    };
 }
 
 #endif // APPROVALTESTS_CPP_SEPARATEAPPROVEDANDRECEIVEDDIRECTORIESNAMER_H

--- a/ApprovalTests/namers/SubdirectoryDisposer.h
+++ b/ApprovalTests/namers/SubdirectoryDisposer.h
@@ -6,24 +6,29 @@
 #include <string>
 #include <utility>
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useApprovalsSubdirectory()
-class APPROVAL_TESTS_NO_DISCARD SubdirectoryDisposer
+namespace ApprovalTests
 {
-private:
-    std::string previous_result;
-public:
-    explicit SubdirectoryDisposer(std::string subdirectory)
+    //! Implementation detail of Approvals::useApprovalsSubdirectory()
+    class APPROVAL_TESTS_NO_DISCARD SubdirectoryDisposer
     {
-        previous_result = ApprovalTestNamer::testConfiguration().subdirectory;
-        ApprovalTestNamer::testConfiguration().subdirectory = std::move(subdirectory);
-    }
+    private:
+        std::string previous_result;
 
-    ~SubdirectoryDisposer()
-    {
-        ApprovalTestNamer::testConfiguration().subdirectory = previous_result;
-    }
-};
+    public:
+        explicit SubdirectoryDisposer(std::string subdirectory)
+        {
+            previous_result =
+                ApprovalTestNamer::testConfiguration().subdirectory;
+            ApprovalTestNamer::testConfiguration().subdirectory =
+                std::move(subdirectory);
+        }
+
+        ~SubdirectoryDisposer()
+        {
+            ApprovalTestNamer::testConfiguration().subdirectory =
+                previous_result;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_SUBDIRECTORYDISPOSER_H

--- a/ApprovalTests/reporters/AutoApproveIfMissingReporter.h
+++ b/ApprovalTests/reporters/AutoApproveIfMissingReporter.h
@@ -5,20 +5,21 @@
 #include "AutoApproveReporter.h"
 #include "ApprovalTests/utilities/FileUtils.h"
 
-namespace ApprovalTests {
-class AutoApproveIfMissingReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    bool report(std::string received, std::string approved) const override
+    class AutoApproveIfMissingReporter : public Reporter
     {
-        if (FileUtils::fileExists(approved))
+    public:
+        bool report(std::string received, std::string approved) const override
         {
-            return false;
-        }
+            if (FileUtils::fileExists(approved))
+            {
+                return false;
+            }
 
-        return AutoApproveReporter().report(received, approved);
-    }
-};
+            return AutoApproveReporter().report(received, approved);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_AUTOAPPROVEIFMISSINGREPORTER_H

--- a/ApprovalTests/reporters/AutoApproveReporter.h
+++ b/ApprovalTests/reporters/AutoApproveReporter.h
@@ -6,17 +6,19 @@
 
 #include <iostream>
 
-namespace ApprovalTests {
-class AutoApproveReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    bool report(std::string received, std::string approved) const override
+    class AutoApproveReporter : public Reporter
     {
-        std::cout << "file " << approved << " automatically approved - next run should succeed\n";
-        FileUtilsSystemSpecific::copyFile( received, approved );
-        return true;
-    }
-};
+    public:
+        bool report(std::string received, std::string approved) const override
+        {
+            std::cout << "file " << approved
+                      << " automatically approved - next run should succeed\n";
+            FileUtilsSystemSpecific::copyFile(received, approved);
+            return true;
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/reporters/BlockingReporter.h
+++ b/ApprovalTests/reporters/BlockingReporter.h
@@ -7,36 +7,43 @@
 #include <memory>
 #include <utility>
 
-namespace ApprovalTests {
-class BlockingReporter : public Reporter
+namespace ApprovalTests
 {
-private:
-    std::shared_ptr<Blocker> blocker;
-
-    BlockingReporter() = delete;
-
-public:
-    explicit BlockingReporter( std::shared_ptr<Blocker> blocker ) : blocker(std::move(blocker))
+    class BlockingReporter : public Reporter
     {
-    }
+    private:
+        std::shared_ptr<Blocker> blocker;
 
-    static std::shared_ptr<BlockingReporter> onMachineNamed( const std::string& machineName )
-    {
-        auto machineBlocker = std::make_shared<MachineBlocker>( MachineBlocker::onMachineNamed(machineName) );
-        return std::make_shared<BlockingReporter>(machineBlocker);
-    }
+        BlockingReporter() = delete;
 
-    static std::shared_ptr<BlockingReporter> onMachinesNotNamed( const std::string& machineName )
-    {
-        auto machineBlocker = std::make_shared<MachineBlocker>( MachineBlocker::onMachinesNotNamed(machineName) );
-        return std::make_shared<BlockingReporter>(machineBlocker);
-    }
+    public:
+        explicit BlockingReporter(std::shared_ptr<Blocker> blocker)
+            : blocker(std::move(blocker))
+        {
+        }
 
-    virtual bool report(std::string /*received*/, std::string /*approved*/) const override
-    {
-        return blocker->isBlockingOnThisMachine();
-    }
-};
+        static std::shared_ptr<BlockingReporter>
+        onMachineNamed(const std::string& machineName)
+        {
+            auto machineBlocker = std::make_shared<MachineBlocker>(
+                MachineBlocker::onMachineNamed(machineName));
+            return std::make_shared<BlockingReporter>(machineBlocker);
+        }
+
+        static std::shared_ptr<BlockingReporter>
+        onMachinesNotNamed(const std::string& machineName)
+        {
+            auto machineBlocker = std::make_shared<MachineBlocker>(
+                MachineBlocker::onMachinesNotNamed(machineName));
+            return std::make_shared<BlockingReporter>(machineBlocker);
+        }
+
+        virtual bool report(std::string /*received*/,
+                            std::string /*approved*/) const override
+        {
+            return blocker->isBlockingOnThisMachine();
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_BLOCKINGREPORTER_H

--- a/ApprovalTests/reporters/CIBuildOnlyReporter.h
+++ b/ApprovalTests/reporters/CIBuildOnlyReporter.h
@@ -17,7 +17,8 @@ namespace ApprovalTests
         std::shared_ptr<Reporter> m_reporter;
 
     public:
-        explicit CIBuildOnlyReporter(std::shared_ptr<Reporter> reporter = std::make_shared<QuietReporter>())
+        explicit CIBuildOnlyReporter(std::shared_ptr<Reporter> reporter =
+                                         std::make_shared<QuietReporter>())
             : m_reporter(reporter)
         {
         }
@@ -53,13 +54,13 @@ namespace ApprovalTests
             });
              */
             auto environmentVariablesForCI = {
-                    // begin-snippet: supported_ci_env_vars
-                    "CI",
-                    "CONTINUOUS_INTEGRATION",
-                    "GO_SERVER_URL",
-                    "JENKINS_URL",
-                    "TEAMCITY_VERSION"
-                    // end-snippet
+                // begin-snippet: supported_ci_env_vars
+                "CI",
+                "CONTINUOUS_INTEGRATION",
+                "GO_SERVER_URL",
+                "JENKINS_URL",
+                "TEAMCITY_VERSION"
+                // end-snippet
             };
             for (const auto& variable : environmentVariablesForCI)
             {

--- a/ApprovalTests/reporters/CIBuildOnlyReporterUtils.h
+++ b/ApprovalTests/reporters/CIBuildOnlyReporterUtils.h
@@ -9,10 +9,11 @@ namespace ApprovalTests
 {
     namespace CIBuildOnlyReporterUtils
     {
-        inline FrontLoadedReporterDisposer useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
+        inline FrontLoadedReporterDisposer
+        useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
         {
             return Approvals::useAsFrontLoadedReporter(
-                    std::make_shared<ApprovalTests::CIBuildOnlyReporter>( reporter ));
+                std::make_shared<ApprovalTests::CIBuildOnlyReporter>(reporter));
         }
     }
 } // namespace ApprovalTests

--- a/ApprovalTests/reporters/ClipboardReporter.h
+++ b/ApprovalTests/reporters/ClipboardReporter.h
@@ -4,29 +4,40 @@
 #include "ApprovalTests/core/Reporter.h"
 #include "ApprovalTests/utilities/SystemUtils.h"
 
-
 #include <string>
 
-namespace ApprovalTests {
-class ClipboardReporter : public Reporter {
-public:
-    static std::string getCommandLineFor(const std::string& received, const std::string& approved, bool isWindows)
+namespace ApprovalTests
+{
+    class ClipboardReporter : public Reporter
     {
-        if (isWindows) {
-            return std::string("move /Y ") + "\"" + received + "\" \"" + approved + "\"";
-        } else {
-            return std::string("mv ") + "\"" + received + "\" \"" + approved + "\"";
+    public:
+        static std::string getCommandLineFor(const std::string& received,
+                                             const std::string& approved,
+                                             bool isWindows)
+        {
+            if (isWindows)
+            {
+                return std::string("move /Y ") + "\"" + received + "\" \"" +
+                       approved + "\"";
+            }
+            else
+            {
+                return std::string("mv ") + "\"" + received + "\" \"" +
+                       approved + "\"";
+            }
         }
-    }
 
-    virtual bool report(std::string received, std::string approved) const override
-    {
-        copyToClipboard(getCommandLineFor(received, approved, SystemUtils::isWindowsOs()));
-        return true;
-    }
+        virtual bool report(std::string received,
+                            std::string approved) const override
+        {
+            copyToClipboard(getCommandLineFor(
+                received, approved, SystemUtils::isWindowsOs()));
+            return true;
+        }
 
-    static void copyToClipboard(const std::string& newClipboard) {
-        /*
+        static void copyToClipboard(const std::string& newClipboard)
+        {
+            /*
          This will probably not work on Linux.
 
          From https://stackoverflow.com/a/750466/104370
@@ -42,23 +53,24 @@ public:
          Under Windows/cygwin, use /dev/clipboard or clip for newer versions of Windows (at least Windows 10).
          */
 
-        std::string clipboardCommand;
-        if (SystemUtils::isWindowsOs())
-        {
-            clipboardCommand = "clip";
+            std::string clipboardCommand;
+            if (SystemUtils::isWindowsOs())
+            {
+                clipboardCommand = "clip";
+            }
+            else if (SystemUtils::isMacOs())
+            {
+                clipboardCommand = "pbcopy";
+            }
+            else
+            {
+                clipboardCommand = "pbclip";
+            }
+            auto cmd =
+                std::string("echo ") + newClipboard + " | " + clipboardCommand;
+            system(cmd.c_str());
         }
-        else if (SystemUtils::isMacOs())
-        {
-            clipboardCommand = "pbcopy";
-        }
-        else
-        {
-            clipboardCommand = "pbclip";
-        }
-        auto cmd = std::string("echo ") + newClipboard + " | " + clipboardCommand;
-        system(cmd.c_str());
-    }
-};
+    };
 }
 
 #endif //APPROVALTESTS_CPP_COMMANDLINEREPORTER_H

--- a/ApprovalTests/reporters/CombinationReporter.h
+++ b/ApprovalTests/reporters/CombinationReporter.h
@@ -5,31 +5,33 @@
 #include <memory>
 #include <vector>
 
-namespace ApprovalTests {
-class CombinationReporter : public Reporter
+namespace ApprovalTests
 {
-private:
-    std::vector< std::unique_ptr<Reporter> > reporters;
-public:
-    // Note that CombinationReporter takes ownership of the given Reporter objects
-    explicit CombinationReporter(const std::vector<Reporter*>& theReporters)
+    class CombinationReporter : public Reporter
     {
-        for(auto r : theReporters)
-        {
-            reporters.push_back(std::unique_ptr<Reporter>(r));
-        }
-    }
+    private:
+        std::vector<std::unique_ptr<Reporter>> reporters;
 
-    bool report(std::string received, std::string approved) const override
-    {
-        bool result = false;
-        for(auto& r : reporters)
+    public:
+        // Note that CombinationReporter takes ownership of the given Reporter objects
+        explicit CombinationReporter(const std::vector<Reporter*>& theReporters)
         {
-            result |= r->report(received, approved);
+            for (auto r : theReporters)
+            {
+                reporters.push_back(std::unique_ptr<Reporter>(r));
+            }
         }
-        return result;
-    }
-};
+
+        bool report(std::string received, std::string approved) const override
+        {
+            bool result = false;
+            for (auto& r : reporters)
+            {
+                result |= r->report(received, approved);
+            }
+            return result;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_COMBINATIONREPORTER_H

--- a/ApprovalTests/reporters/CommandReporter.h
+++ b/ApprovalTests/reporters/CommandReporter.h
@@ -6,32 +6,38 @@
 #include "ApprovalTests/utilities/FileUtils.h"
 #include "ApprovalTests/core/Reporter.h"
 
-namespace ApprovalTests {
-// Generic reporter to launch arbitrary command
-class CommandReporter : public Reporter {
-private:
-    std::string cmd;
-    CommandLauncher *l;
-
-protected:
-    CommandReporter(std::string command, CommandLauncher *launcher)
-            : cmd(std::move(command)), l(launcher) {
-    }
-
-public:
-    bool report(std::string received, std::string approved) const override {
-        FileUtils::ensureFileExists(approved);
-        return l->launch(getFullCommand(received, approved));
-    }
-
-    std::vector<std::string> getFullCommand(const std::string &received, const std::string &approved) const
+namespace ApprovalTests
+{
+    // Generic reporter to launch arbitrary command
+    class CommandReporter : public Reporter
     {
-        std::vector<std::string> fullCommand;
-        fullCommand.push_back(cmd);
-        fullCommand.push_back(received);
-        fullCommand.push_back(approved);
-        return fullCommand;
-    }
-};
+    private:
+        std::string cmd;
+        CommandLauncher* l;
+
+    protected:
+        CommandReporter(std::string command, CommandLauncher* launcher)
+            : cmd(std::move(command)), l(launcher)
+        {
+        }
+
+    public:
+        bool report(std::string received, std::string approved) const override
+        {
+            FileUtils::ensureFileExists(approved);
+            return l->launch(getFullCommand(received, approved));
+        }
+
+        std::vector<std::string>
+        getFullCommand(const std::string& received,
+                       const std::string& approved) const
+        {
+            std::vector<std::string> fullCommand;
+            fullCommand.push_back(cmd);
+            fullCommand.push_back(received);
+            fullCommand.push_back(approved);
+            return fullCommand;
+        }
+    };
 }
 #endif //APPROVALTESTS_CPP_COMMANDREPORTER_H

--- a/ApprovalTests/reporters/DefaultFrontLoadedReporter.h
+++ b/ApprovalTests/reporters/DefaultFrontLoadedReporter.h
@@ -4,18 +4,16 @@
 #include "ApprovalTests/reporters/CIBuildOnlyReporter.h"
 #include "ApprovalTests/reporters/FirstWorkingReporter.h"
 
-namespace ApprovalTests {
-class DefaultFrontLoadedReporter : public FirstWorkingReporter
+namespace ApprovalTests
 {
-public:
-    DefaultFrontLoadedReporter() : FirstWorkingReporter(
-        {
-            new CIBuildOnlyReporter()
-        }
-    )
+    class DefaultFrontLoadedReporter : public FirstWorkingReporter
     {
-    }
-};
+    public:
+        DefaultFrontLoadedReporter()
+            : FirstWorkingReporter({new CIBuildOnlyReporter()})
+        {
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTFRONTLOADEDREPORTER_H

--- a/ApprovalTests/reporters/DefaultReporter.h
+++ b/ApprovalTests/reporters/DefaultReporter.h
@@ -6,15 +6,18 @@
 
 #include <string>
 
-namespace ApprovalTests {
-class DefaultReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    virtual bool report(std::string received, std::string approved) const override
+    class DefaultReporter : public Reporter
     {
-        return DefaultReporterFactory::getDefaultReporter()->report(received, approved);
-    }
-};
+    public:
+        virtual bool report(std::string received,
+                            std::string approved) const override
+        {
+            return DefaultReporterFactory::getDefaultReporter()->report(
+                received, approved);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTREPORTER_H

--- a/ApprovalTests/reporters/DefaultReporterDisposer.h
+++ b/ApprovalTests/reporters/DefaultReporterDisposer.h
@@ -3,24 +3,27 @@
 
 #include "DefaultReporterFactory.h"
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useAsDefaultReporter()
-class APPROVAL_TESTS_NO_DISCARD DefaultReporterDisposer
+namespace ApprovalTests
 {
-private:
-    std::shared_ptr<Reporter> previous_result;
-public:
-    explicit DefaultReporterDisposer(const std::shared_ptr<Reporter>& reporter)
+    //! Implementation detail of Approvals::useAsDefaultReporter()
+    class APPROVAL_TESTS_NO_DISCARD DefaultReporterDisposer
     {
-        previous_result = DefaultReporterFactory::getDefaultReporter();
-        DefaultReporterFactory::setDefaultReporter(reporter);
-    }
+    private:
+        std::shared_ptr<Reporter> previous_result;
 
-    ~DefaultReporterDisposer()
-    {
-        DefaultReporterFactory::setDefaultReporter(previous_result);
-    }
-};
+    public:
+        explicit DefaultReporterDisposer(
+            const std::shared_ptr<Reporter>& reporter)
+        {
+            previous_result = DefaultReporterFactory::getDefaultReporter();
+            DefaultReporterFactory::setDefaultReporter(reporter);
+        }
+
+        ~DefaultReporterDisposer()
+        {
+            DefaultReporterFactory::setDefaultReporter(previous_result);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTREPORTERDISPOSER_H

--- a/ApprovalTests/reporters/DefaultReporterFactory.h
+++ b/ApprovalTests/reporters/DefaultReporterFactory.h
@@ -6,31 +6,33 @@
 
 #include <memory>
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useAsDefaultReporter()
-class DefaultReporterFactory
+namespace ApprovalTests
 {
-// begin-snippet: static_variable_sample
-private:
-    static std::shared_ptr<Reporter>& defaultReporter()
+    //! Implementation detail of Approvals::useAsDefaultReporter()
+    class DefaultReporterFactory
     {
-        static std::shared_ptr<Reporter> reporter = std::make_shared<DiffReporter>();
-        return reporter;
-    }
+        // begin-snippet: static_variable_sample
+    private:
+        static std::shared_ptr<Reporter>& defaultReporter()
+        {
+            static std::shared_ptr<Reporter> reporter =
+                std::make_shared<DiffReporter>();
+            return reporter;
+        }
 
-public:
-    static std::shared_ptr<Reporter> getDefaultReporter()
-    {
-        return defaultReporter();
-    }
-    
-    static void setDefaultReporter( const std::shared_ptr<Reporter>& reporter)
-    {
-        defaultReporter() = reporter;
-    }
-// end-snippet
+    public:
+        static std::shared_ptr<Reporter> getDefaultReporter()
+        {
+            return defaultReporter();
+        }
 
-};
+        static void
+        setDefaultReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            defaultReporter() = reporter;
+        }
+        // end-snippet
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DEFAULTREPORTERFACTORY_H

--- a/ApprovalTests/reporters/DiffInfo.h
+++ b/ApprovalTests/reporters/DiffInfo.h
@@ -7,60 +7,59 @@
 #include "ApprovalTests/utilities/StringUtils.h"
 #include "ApprovalTests/utilities/SystemUtils.h"
 
-namespace ApprovalTests {
-enum class Type { TEXT, IMAGE, TEXT_AND_IMAGE };
-
-
-
-struct DiffInfo
+namespace ApprovalTests
 {
-    DiffInfo(std::string program, Type type) :
-        program(std::move(program)),
-        arguments("%s %s"),
-        type(type)
+    enum class Type
     {
-    }
-    DiffInfo(std::string program, std::string arguments, Type type) :
-        program(std::move(program)),
-        arguments(std::move(arguments)),
-        type(type)
-    {
-    }
-    std::string program;
-    std::string arguments;
-    Type type;
+        TEXT,
+        IMAGE,
+        TEXT_AND_IMAGE
+    };
 
-    std::string getProgramForOs() const
+    struct DiffInfo
     {
-        std::string result = program;
-        if (result.rfind("{ProgramFiles}", 0) == 0)
+        DiffInfo(std::string program, Type type)
+            : program(std::move(program)), arguments("%s %s"), type(type)
         {
-            const std::vector<const char*> envVars =
-            {
-                "ProgramFiles",
-                "ProgramW6432",
-                "ProgramFiles(x86)"
-            };
+        }
+        DiffInfo(std::string program, std::string arguments, Type type)
+            : program(std::move(program))
+            , arguments(std::move(arguments))
+            , type(type)
+        {
+        }
+        std::string program;
+        std::string arguments;
+        Type type;
 
-            for(const auto& envVar : envVars)
+        std::string getProgramForOs() const
+        {
+            std::string result = program;
+            if (result.rfind("{ProgramFiles}", 0) == 0)
             {
-                std::string envVarValue = SystemUtils::safeGetEnv(envVar);
-                if (envVarValue.empty())
-                {
-                    continue;
-                }
-                envVarValue += '\\';
+                const std::vector<const char*> envVars = {
+                    "ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"};
 
-                auto result1 = StringUtils::replaceAll(result, "{ProgramFiles}", envVarValue);
-                if (FileUtils::fileExists(result1))
+                for (const auto& envVar : envVars)
                 {
-                    return result1;
+                    std::string envVarValue = SystemUtils::safeGetEnv(envVar);
+                    if (envVarValue.empty())
+                    {
+                        continue;
+                    }
+                    envVarValue += '\\';
+
+                    auto result1 = StringUtils::replaceAll(
+                        result, "{ProgramFiles}", envVarValue);
+                    if (FileUtils::fileExists(result1))
+                    {
+                        return result1;
+                    }
                 }
             }
+            return result;
         }
-        return result;
-    }
-};
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DIFFINFO_H

--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -4,62 +4,126 @@
 #include "DiffInfo.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-#define APPROVAL_TESTS_MACROS_ENTRY(name, defaultValue) \
-        inline DiffInfo name() { return defaultValue; }
+#define APPROVAL_TESTS_MACROS_ENTRY(name, defaultValue)                        \
+    inline DiffInfo name()                                                     \
+    {                                                                          \
+        return defaultValue;                                                   \
+    }
 ///////////////////////////////////////////////////////////////////////////////
 
-namespace ApprovalTests {
-namespace DiffPrograms {
+namespace ApprovalTests
+{
+    namespace DiffPrograms
+    {
 
+        namespace Mac
+        {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                DIFF_MERGE,
+                DiffInfo("/Applications/DiffMerge.app/Contents/MacOS/DiffMerge",
+                         "%s %s -nosplash",
+                         Type::TEXT))
 
-    namespace Mac {
-        APPROVAL_TESTS_MACROS_ENTRY(DIFF_MERGE,
-              DiffInfo("/Applications/DiffMerge.app/Contents/MacOS/DiffMerge", "%s %s -nosplash", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE,
+                DiffInfo(
+                    "/Applications/Beyond Compare.app/Contents/MacOS/bcomp",
+                    Type::TEXT))
 
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE, DiffInfo("/Applications/Beyond Compare.app/Contents/MacOS/bcomp", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                KALEIDOSCOPE,
+                DiffInfo("/Applications/Kaleidoscope.app/Contents/MacOS/ksdiff",
+                         Type::TEXT_AND_IMAGE))
 
-        APPROVAL_TESTS_MACROS_ENTRY(KALEIDOSCOPE, DiffInfo("/Applications/Kaleidoscope.app/Contents/MacOS/ksdiff", Type::TEXT_AND_IMAGE))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                KDIFF3,
+                DiffInfo("/Applications/kdiff3.app/Contents/MacOS/kdiff3",
+                         "%s %s -m",
+                         Type::TEXT))
 
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("/Applications/kdiff3.app/Contents/MacOS/kdiff3", "%s %s -m", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                P4MERGE,
+                DiffInfo("/Applications/p4merge.app/Contents/MacOS/p4merge",
+                         Type::TEXT_AND_IMAGE))
 
-        APPROVAL_TESTS_MACROS_ENTRY(P4MERGE, DiffInfo("/Applications/p4merge.app/Contents/MacOS/p4merge", Type::TEXT_AND_IMAGE))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TK_DIFF,
+                DiffInfo("/Applications/TkDiff.app/Contents/MacOS/tkdiff",
+                         Type::TEXT))
 
-        APPROVAL_TESTS_MACROS_ENTRY(TK_DIFF, DiffInfo("/Applications/TkDiff.app/Contents/MacOS/tkdiff", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                VS_CODE,
+                DiffInfo("/Applications/Visual Studio "
+                         "Code.app/Contents/Resources/app/bin/code",
+                         "-d %s %s",
+                         Type::TEXT))
+        }
+        namespace Linux
+        {
+            // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
+            APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("kdiff3", Type::TEXT))
 
-        APPROVAL_TESTS_MACROS_ENTRY(VS_CODE, DiffInfo("/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code", "-d %s %s", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(MELD, DiffInfo("meld", Type::TEXT))
+        }
+        namespace Windows
+        {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE_3,
+                DiffInfo("{ProgramFiles}Beyond Compare 3\\BCompare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE_4,
+                DiffInfo("{ProgramFiles}Beyond Compare 4\\BCompare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_IMAGE_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseIDiff.exe",
+                         "/left:%s /right:%s",
+                         Type::IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_TEXT_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_GIT_IMAGE_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitIDiff.exe",
+                         "/left:%s /right:%s",
+                         Type::IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_GIT_TEXT_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitMerge.exe",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                WIN_MERGE_REPORTER,
+                DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                ARAXIS_MERGE,
+                DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                CODE_COMPARE,
+                DiffInfo("{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                KDIFF3,
+                DiffInfo("{ProgramFiles}KDiff3\\kdiff3.exe", Type::TEXT))
+            APPROVAL_TESTS_MACROS_ENTRY(
+                VS_CODE,
+                DiffInfo("{ProgramFiles}Microsoft VS Code\\Code.exe",
+                         "-d %s %s",
+                         Type::TEXT))
+        }
     }
-    namespace Linux {
-        // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("kdiff3", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(MELD, DiffInfo("meld", Type::TEXT))
-    }
-    namespace Windows {
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE_3, DiffInfo("{ProgramFiles}Beyond Compare 3\\BCompare.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE_4, DiffInfo("{ProgramFiles}Beyond Compare 4\\BCompare.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_IMAGE_DIFF,
-              DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseIDiff.exe", "/left:%s /right:%s", Type::IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_TEXT_DIFF, DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_GIT_IMAGE_DIFF,
-              DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitIDiff.exe", "/left:%s /right:%s", Type::IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_GIT_TEXT_DIFF, DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitMerge.exe", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(WIN_MERGE_REPORTER, DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(ARAXIS_MERGE, DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(CODE_COMPARE, DiffInfo("{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("{ProgramFiles}KDiff3\\kdiff3.exe", Type::TEXT))
-        APPROVAL_TESTS_MACROS_ENTRY(VS_CODE, DiffInfo("{ProgramFiles}Microsoft VS Code\\Code.exe", "-d %s %s", Type::TEXT))
-
-    }
-}
 }
 
 #endif //APPROVALTESTS_CPP_DIFFPROGRAMS_H

--- a/ApprovalTests/reporters/DiffReporter.h
+++ b/ApprovalTests/reporters/DiffReporter.h
@@ -6,20 +6,18 @@
 #include "MacReporters.h"
 #include "LinuxReporters.h"
 
-namespace ApprovalTests {
-class DiffReporter : public FirstWorkingReporter
+namespace ApprovalTests
 {
-public:
-    DiffReporter() : FirstWorkingReporter(
-            {
-                    new Mac::MacDiffReporter(),
-                    new Linux::LinuxDiffReporter(),
-                    new Windows::WindowsDiffReporter()
-            }
-    )
+    class DiffReporter : public FirstWorkingReporter
     {
-    }
-};
+    public:
+        DiffReporter()
+            : FirstWorkingReporter({new Mac::MacDiffReporter(),
+                                    new Linux::LinuxDiffReporter(),
+                                    new Windows::WindowsDiffReporter()})
+        {
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_DIFFREPORTER_H

--- a/ApprovalTests/reporters/FirstWorkingReporter.h
+++ b/ApprovalTests/reporters/FirstWorkingReporter.h
@@ -5,33 +5,36 @@
 #include <memory>
 #include <vector>
 
-namespace ApprovalTests {
-class FirstWorkingReporter : public Reporter
+namespace ApprovalTests
 {
-private:
-    std::vector< std::unique_ptr<Reporter> > reporters;
-public:
-    // Note that FirstWorkingReporter takes ownership of the given Reporter objects
-    explicit FirstWorkingReporter(const std::vector<Reporter*>& theReporters)
+    class FirstWorkingReporter : public Reporter
     {
-        for(auto r : theReporters)
-        {
-            reporters.push_back(std::unique_ptr<Reporter>(r));
-        }
-    }
+    private:
+        std::vector<std::unique_ptr<Reporter>> reporters;
 
-    bool report(std::string received, std::string approved) const override
-    {
-        for(auto& r : reporters)
+    public:
+        // Note that FirstWorkingReporter takes ownership of the given Reporter objects
+        explicit FirstWorkingReporter(
+            const std::vector<Reporter*>& theReporters)
         {
-            if (r->report(received, approved))
+            for (auto r : theReporters)
             {
-                return true;
+                reporters.push_back(std::unique_ptr<Reporter>(r));
             }
         }
-        return false;
-    }
-};
+
+        bool report(std::string received, std::string approved) const override
+        {
+            for (auto& r : reporters)
+            {
+                if (r->report(received, approved))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_FIRSTWORKINGREPORTER_H

--- a/ApprovalTests/reporters/FrontLoadedReporterDisposer.h
+++ b/ApprovalTests/reporters/FrontLoadedReporterDisposer.h
@@ -3,25 +3,28 @@
 
 #include "FrontLoadedReporterFactory.h"
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useAsFrontLoadedReporter()
-class APPROVAL_TESTS_NO_DISCARD FrontLoadedReporterDisposer
+namespace ApprovalTests
 {
-private:
-    std::shared_ptr<Reporter> previous_result;
-public:
-    explicit FrontLoadedReporterDisposer(const std::shared_ptr<Reporter>& reporter)
+    //! Implementation detail of Approvals::useAsFrontLoadedReporter()
+    class APPROVAL_TESTS_NO_DISCARD FrontLoadedReporterDisposer
     {
-        previous_result = FrontLoadedReporterFactory::getFrontLoadedReporter();
-        FrontLoadedReporterFactory::setFrontLoadedReporter(reporter);
-    }
+    private:
+        std::shared_ptr<Reporter> previous_result;
 
-    ~FrontLoadedReporterDisposer()
-    {
-        FrontLoadedReporterFactory::setFrontLoadedReporter(previous_result);
-    }
+    public:
+        explicit FrontLoadedReporterDisposer(
+            const std::shared_ptr<Reporter>& reporter)
+        {
+            previous_result =
+                FrontLoadedReporterFactory::getFrontLoadedReporter();
+            FrontLoadedReporterFactory::setFrontLoadedReporter(reporter);
+        }
 
-};
+        ~FrontLoadedReporterDisposer()
+        {
+            FrontLoadedReporterFactory::setFrontLoadedReporter(previous_result);
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_FRONTLOADEDREPORTERDISPOSER_H

--- a/ApprovalTests/reporters/FrontLoadedReporterFactory.h
+++ b/ApprovalTests/reporters/FrontLoadedReporterFactory.h
@@ -6,27 +6,30 @@
 
 #include <memory>
 
-namespace ApprovalTests {
-//! Implementation detail of Approvals::useAsFrontLoadedReporter()
-class FrontLoadedReporterFactory
+namespace ApprovalTests
 {
-    static std::shared_ptr<Reporter>& frontLoadedReporter()
+    //! Implementation detail of Approvals::useAsFrontLoadedReporter()
+    class FrontLoadedReporterFactory
     {
-        static std::shared_ptr<Reporter> reporter = std::make_shared<DefaultFrontLoadedReporter>();
-        return reporter;
-    }
+        static std::shared_ptr<Reporter>& frontLoadedReporter()
+        {
+            static std::shared_ptr<Reporter> reporter =
+                std::make_shared<DefaultFrontLoadedReporter>();
+            return reporter;
+        }
 
-public:
-    static std::shared_ptr<Reporter> getFrontLoadedReporter()
-    {
-        return frontLoadedReporter();
-    }
+    public:
+        static std::shared_ptr<Reporter> getFrontLoadedReporter()
+        {
+            return frontLoadedReporter();
+        }
 
-    static void setFrontLoadedReporter( const std::shared_ptr<Reporter>& reporter)
-    {
-        frontLoadedReporter() = reporter;
-    }
-};
+        static void
+        setFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            frontLoadedReporter() = reporter;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_FRONTLOADEDREPORTERFACTORY_H

--- a/ApprovalTests/reporters/GenericDiffReporter.h
+++ b/ApprovalTests/reporters/GenericDiffReporter.h
@@ -7,49 +7,56 @@
 #include <string>
 #include <vector>
 
-namespace ApprovalTests {
-class GenericDiffReporter : public CommandReporter {
-private:
-    SystemLauncher launcher;
-public:
-    explicit GenericDiffReporter(const std::string& program) : CommandReporter(program, &launcher)
+namespace ApprovalTests
+{
+    class GenericDiffReporter : public CommandReporter
     {
-        checkForCygwin();
-    }
-    explicit GenericDiffReporter(const DiffInfo& info) : CommandReporter(info.getProgramForOs(), &launcher)
-    {
-        checkForCygwin();
-    }
+    private:
+        SystemLauncher launcher;
 
-    void checkForCygwin()
-    {
-        if ( SystemUtils::isCygwin())
+    public:
+        explicit GenericDiffReporter(const std::string& program)
+            : CommandReporter(program, &launcher)
         {
-            launcher.setConvertArgumentsForSystemLaunchingFunction(convertForCygwin);
+            checkForCygwin();
         }
-    }
+        explicit GenericDiffReporter(const DiffInfo& info)
+            : CommandReporter(info.getProgramForOs(), &launcher)
+        {
+            checkForCygwin();
+        }
 
-    static std::vector<std::string> convertForCygwin(std::vector<std::string> argv)
-    {
-        if (! SystemUtils::isCygwin())
+        void checkForCygwin()
         {
-            return argv;
-        }
-        std::vector<std::string> copy = argv;
-        for( size_t i = 0; i != argv.size(); ++i )
-        {
-            if ( i == 0)
+            if (SystemUtils::isCygwin())
             {
-                copy[i] = "$(cygpath '"  + argv[i] + "')";
-            }
-            else
-            {
-                copy[i] = "$(cygpath -aw '"  + argv[i] + "')";
+                launcher.setConvertArgumentsForSystemLaunchingFunction(
+                    convertForCygwin);
             }
         }
-        return copy;
-    }
-};
+
+        static std::vector<std::string>
+        convertForCygwin(std::vector<std::string> argv)
+        {
+            if (!SystemUtils::isCygwin())
+            {
+                return argv;
+            }
+            std::vector<std::string> copy = argv;
+            for (size_t i = 0; i != argv.size(); ++i)
+            {
+                if (i == 0)
+                {
+                    copy[i] = "$(cygpath '" + argv[i] + "')";
+                }
+                else
+                {
+                    copy[i] = "$(cygpath -aw '" + argv[i] + "')";
+                }
+            }
+            return copy;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_GENERICDIFFREPORTER_H

--- a/ApprovalTests/reporters/LinuxReporters.h
+++ b/ApprovalTests/reporters/LinuxReporters.h
@@ -5,35 +5,41 @@
 #include "GenericDiffReporter.h"
 #include "FirstWorkingReporter.h"
 
-namespace ApprovalTests {
-namespace Linux
+namespace ApprovalTests
 {
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Linux::KDIFF3()) {}
-    };
-
-    class MeldReporter : public GenericDiffReporter {
-    public:
-        MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD()) {}
-    };
-
-    class LinuxDiffReporter : public FirstWorkingReporter
+    namespace Linux
     {
-    public:
-        LinuxDiffReporter() : FirstWorkingReporter(
-                {
-                        // begin-snippet: linux_diff_reporters
-                        new MeldReporter(),
-                        new KDiff3Reporter()
-                        // end-snippet
-                }
-        )
+        class KDiff3Reporter : public GenericDiffReporter
         {
-        }
-    };
+        public:
+            KDiff3Reporter()
+                : GenericDiffReporter(DiffPrograms::Linux::KDIFF3())
+            {
+            }
+        };
 
-}
+        class MeldReporter : public GenericDiffReporter
+        {
+        public:
+            MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD())
+            {
+            }
+        };
+
+        class LinuxDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            LinuxDiffReporter()
+                : FirstWorkingReporter({
+                      // begin-snippet: linux_diff_reporters
+                      new MeldReporter(),
+                      new KDiff3Reporter()
+                      // end-snippet
+                  })
+            {
+            }
+        };
+    }
 }
 
 #endif //APPROVALTESTS_CPP_LINUXREPORTERS_H

--- a/ApprovalTests/reporters/MacReporters.h
+++ b/ApprovalTests/reporters/MacReporters.h
@@ -5,61 +5,90 @@
 #include "GenericDiffReporter.h"
 #include "FirstWorkingReporter.h"
 
-namespace ApprovalTests {
-namespace Mac {
-    class DiffMergeReporter : public GenericDiffReporter {
-    public:
-        DiffMergeReporter() : GenericDiffReporter(DiffPrograms::Mac::DIFF_MERGE()) {}
-    };
+namespace ApprovalTests
+{
+    namespace Mac
+    {
+        class DiffMergeReporter : public GenericDiffReporter
+        {
+        public:
+            DiffMergeReporter()
+                : GenericDiffReporter(DiffPrograms::Mac::DIFF_MERGE())
+            {
+            }
+        };
 
-    class VisualStudioCodeReporter : public GenericDiffReporter {
-    public:
-        VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Mac::VS_CODE()) {}
-    };
+        class VisualStudioCodeReporter : public GenericDiffReporter
+        {
+        public:
+            VisualStudioCodeReporter()
+                : GenericDiffReporter(DiffPrograms::Mac::VS_CODE())
+            {
+            }
+        };
 
-    class BeyondCompareReporter : public GenericDiffReporter {
-    public:
-        BeyondCompareReporter() : GenericDiffReporter(DiffPrograms::Mac::BEYOND_COMPARE()) {}
-    };
+        class BeyondCompareReporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompareReporter()
+                : GenericDiffReporter(DiffPrograms::Mac::BEYOND_COMPARE())
+            {
+            }
+        };
 
-    class KaleidoscopeReporter : public GenericDiffReporter {
-    public:
-        KaleidoscopeReporter() : GenericDiffReporter(DiffPrograms::Mac::KALEIDOSCOPE()) {}
-    };
+        class KaleidoscopeReporter : public GenericDiffReporter
+        {
+        public:
+            KaleidoscopeReporter()
+                : GenericDiffReporter(DiffPrograms::Mac::KALEIDOSCOPE())
+            {
+            }
+        };
 
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Mac::KDIFF3()) {}
-    };
+        class KDiff3Reporter : public GenericDiffReporter
+        {
+        public:
+            KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Mac::KDIFF3())
+            {
+            }
+        };
 
-    class P4MergeReporter : public GenericDiffReporter {
-    public:
-        P4MergeReporter() : GenericDiffReporter(DiffPrograms::Mac::P4MERGE()) {}
-    };
+        class P4MergeReporter : public GenericDiffReporter
+        {
+        public:
+            P4MergeReporter()
+                : GenericDiffReporter(DiffPrograms::Mac::P4MERGE())
+            {
+            }
+        };
 
-    class TkDiffReporter : public GenericDiffReporter {
-    public:
-        TkDiffReporter() : GenericDiffReporter(DiffPrograms::Mac::TK_DIFF()) {}
-    };
+        class TkDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TkDiffReporter() : GenericDiffReporter(DiffPrograms::Mac::TK_DIFF())
+            {
+            }
+        };
 
-    class MacDiffReporter : public FirstWorkingReporter {
-    public:
-        MacDiffReporter() : FirstWorkingReporter(
-                {
-                        // begin-snippet: mac_diff_reporters
-                        new BeyondCompareReporter(),
-                        new DiffMergeReporter(),
-                        new KaleidoscopeReporter(),
-                        new P4MergeReporter(),
-                        new KDiff3Reporter(),
-                        new TkDiffReporter(),
-                        new VisualStudioCodeReporter()
-                        // end-snippet
-                }
-        ) {
-        }
-    };
-}
+        class MacDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            MacDiffReporter()
+                : FirstWorkingReporter({
+                      // begin-snippet: mac_diff_reporters
+                      new BeyondCompareReporter(),
+                      new DiffMergeReporter(),
+                      new KaleidoscopeReporter(),
+                      new P4MergeReporter(),
+                      new KDiff3Reporter(),
+                      new TkDiffReporter(),
+                      new VisualStudioCodeReporter()
+                      // end-snippet
+                  })
+            {
+            }
+        };
+    }
 }
 
 #endif //APPROVALTESTS_CPP_MACREPORTERS_H

--- a/ApprovalTests/reporters/QuietReporter.h
+++ b/ApprovalTests/reporters/QuietReporter.h
@@ -3,16 +3,18 @@
 
 #include "ApprovalTests/core/Reporter.h"
 
-namespace ApprovalTests {
-// A reporter that does nothing. Failing tests will still fail, but nothing will be launched.
-class QuietReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    bool report(std::string /*received*/, std::string /*approved*/) const override
+    // A reporter that does nothing. Failing tests will still fail, but nothing will be launched.
+    class QuietReporter : public Reporter
     {
-        return true;
-    }
-};
+    public:
+        bool report(std::string /*received*/,
+                    std::string /*approved*/) const override
+        {
+            return true;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_QUIETREPORTER_H

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -5,107 +5,169 @@
 #include "FirstWorkingReporter.h"
 #include "GenericDiffReporter.h"
 
-namespace ApprovalTests {
-namespace Windows {
+namespace ApprovalTests
+{
+    namespace Windows
+    {
 
-    class VisualStudioCodeReporter : public GenericDiffReporter {
-    public:
-        VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Windows::VS_CODE()) {}
-    };
-
-    // ----------------------- Beyond Compare ----------------------------------
-    class BeyondCompare3Reporter : public GenericDiffReporter {
-    public:
-        BeyondCompare3Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3()) {}
-    };
-
-    class BeyondCompare4Reporter : public GenericDiffReporter {
-    public:
-        BeyondCompare4Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4()) {}
-    };
-
-    class BeyondCompareReporter : public FirstWorkingReporter {
-    public:
-        BeyondCompareReporter() : FirstWorkingReporter({new BeyondCompare4Reporter(), new BeyondCompare3Reporter()}) {
-        }
-    };
-
-    // ----------------------- Tortoise SVN ------------------------------------
-    class TortoiseImageDiffReporter : public GenericDiffReporter {
-    public:
-        TortoiseImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_IMAGE_DIFF()) {}
-    };
-
-    class TortoiseTextDiffReporter : public GenericDiffReporter {
-    public:
-        TortoiseTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF()) {}
-    };
-
-    class TortoiseDiffReporter : public FirstWorkingReporter {
-    public:
-        TortoiseDiffReporter() : FirstWorkingReporter(
-                {new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
-        }
-    };
-
-    // ----------------------- Tortoise Git ------------------------------------
-    class TortoiseGitTextDiffReporter : public GenericDiffReporter {
+        class VisualStudioCodeReporter : public GenericDiffReporter
+        {
         public:
-        TortoiseGitTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_TEXT_DIFF()) {}
-    };
+            VisualStudioCodeReporter()
+                : GenericDiffReporter(DiffPrograms::Windows::VS_CODE())
+            {
+            }
+        };
 
-    class TortoiseGitImageDiffReporter : public GenericDiffReporter {
+        // ----------------------- Beyond Compare ----------------------------------
+        class BeyondCompare3Reporter : public GenericDiffReporter
+        {
         public:
-        TortoiseGitImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_IMAGE_DIFF()) {}
-    };
+            BeyondCompare3Reporter()
+                : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3())
+            {
+            }
+        };
 
-    class TortoiseGitDiffReporter : public FirstWorkingReporter {
-    public:
-        TortoiseGitDiffReporter() : FirstWorkingReporter(
-                {new TortoiseGitTextDiffReporter(), new TortoiseGitImageDiffReporter()}) {
-        }
-    };
+        class BeyondCompare4Reporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompare4Reporter()
+                : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4())
+            {
+            }
+        };
 
-    // -------------------------------------------------------------------------
-    class WinMergeReporter : public GenericDiffReporter {
-    public:
-        WinMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::WIN_MERGE_REPORTER()) {}
-    };
+        class BeyondCompareReporter : public FirstWorkingReporter
+        {
+        public:
+            BeyondCompareReporter()
+                : FirstWorkingReporter({new BeyondCompare4Reporter(),
+                                        new BeyondCompare3Reporter()})
+            {
+            }
+        };
 
-    class AraxisMergeReporter : public GenericDiffReporter {
-    public:
-        AraxisMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE()) {}
-    };
+        // ----------------------- Tortoise SVN ------------------------------------
+        class TortoiseImageDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseImageDiffReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Windows::TORTOISE_IMAGE_DIFF())
+            {
+            }
+        };
 
-    class CodeCompareReporter : public GenericDiffReporter {
-    public:
-        CodeCompareReporter() : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE()) {}
-    };
+        class TortoiseTextDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseTextDiffReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Windows::TORTOISE_TEXT_DIFF())
+            {
+            }
+        };
 
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Windows::KDIFF3()) {}
-    };
+        class TortoiseDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            TortoiseDiffReporter()
+                : FirstWorkingReporter({new TortoiseTextDiffReporter(),
+                                        new TortoiseImageDiffReporter()})
+            {
+            }
+        };
 
-    class WindowsDiffReporter : public FirstWorkingReporter {
-    public:
-        WindowsDiffReporter() : FirstWorkingReporter(
-                {
-                        // begin-snippet: windows_diff_reporters
-                        new TortoiseDiffReporter(), // Note that this uses Tortoise SVN Diff
-                        new TortoiseGitDiffReporter(),
-                        new BeyondCompareReporter(),
-                        new WinMergeReporter(),
-                        new AraxisMergeReporter(),
-                        new CodeCompareReporter(),
-                        new KDiff3Reporter(),
-                        new VisualStudioCodeReporter(),
-                        // end-snippet
-                }
-        ) {
-        }
-    };
-}
+        // ----------------------- Tortoise Git ------------------------------------
+        class TortoiseGitTextDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseGitTextDiffReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Windows::TORTOISE_GIT_TEXT_DIFF())
+            {
+            }
+        };
+
+        class TortoiseGitImageDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseGitImageDiffReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Windows::TORTOISE_GIT_IMAGE_DIFF())
+            {
+            }
+        };
+
+        class TortoiseGitDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            TortoiseGitDiffReporter()
+                : FirstWorkingReporter({new TortoiseGitTextDiffReporter(),
+                                        new TortoiseGitImageDiffReporter()})
+            {
+            }
+        };
+
+        // -------------------------------------------------------------------------
+        class WinMergeReporter : public GenericDiffReporter
+        {
+        public:
+            WinMergeReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Windows::WIN_MERGE_REPORTER())
+            {
+            }
+        };
+
+        class AraxisMergeReporter : public GenericDiffReporter
+        {
+        public:
+            AraxisMergeReporter()
+                : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE())
+            {
+            }
+        };
+
+        class CodeCompareReporter : public GenericDiffReporter
+        {
+        public:
+            CodeCompareReporter()
+                : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE())
+            {
+            }
+        };
+
+        class KDiff3Reporter : public GenericDiffReporter
+        {
+        public:
+            KDiff3Reporter()
+                : GenericDiffReporter(DiffPrograms::Windows::KDIFF3())
+            {
+            }
+        };
+
+        class WindowsDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            WindowsDiffReporter()
+                : FirstWorkingReporter({
+                      // begin-snippet: windows_diff_reporters
+                      new TortoiseDiffReporter(), // Note that this uses Tortoise SVN Diff
+                      new TortoiseGitDiffReporter(),
+                      new BeyondCompareReporter(),
+                      new WinMergeReporter(),
+                      new AraxisMergeReporter(),
+                      new CodeCompareReporter(),
+                      new KDiff3Reporter(),
+                      new VisualStudioCodeReporter(),
+                      // end-snippet
+                  })
+            {
+            }
+        };
+    }
 }
 
 #endif //APPROVALTESTS_CPP_WINDOWSREPORTERS_H

--- a/ApprovalTests/utilities/Blocker.h
+++ b/ApprovalTests/utilities/Blocker.h
@@ -1,13 +1,14 @@
 #ifndef APPROVALTESTS_CPP_BLOCKER_H
 #define APPROVALTESTS_CPP_BLOCKER_H
 
-namespace ApprovalTests {
-class Blocker
+namespace ApprovalTests
 {
-public:
-    virtual ~Blocker() = default;
-    virtual bool isBlockingOnThisMachine() const = 0;
-};
+    class Blocker
+    {
+    public:
+        virtual ~Blocker() = default;
+        virtual bool isBlockingOnThisMachine() const = 0;
+    };
 }
 
 #endif //APPROVALTESTS_CPP_BLOCKER_H

--- a/ApprovalTests/utilities/CartesianProduct.h
+++ b/ApprovalTests/utilities/CartesianProduct.h
@@ -7,170 +7,217 @@
 #include <utility>
 #include <vector>
 
-namespace ApprovalTests {
-namespace CartesianProduct {
-namespace Detail {
-
-// C++14 compatibility
-// See https://en.cppreference.com/w/cpp/types/enable_if
-template<bool B, class T=void>
-using enable_if_t = typename std::enable_if<B, T>::type;
-
-// See https://en.cppreference.com/w/cpp/utility/integer_sequence
-template<std::size_t... Is>
-struct index_sequence {};
-
-template<std::size_t N, std::size_t... Is>
-struct make_index_sequence : make_index_sequence<N-1, N-1, Is...> {};
-
-template<std::size_t... Is>
-struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
-// End of C++14 compatibility
-
-// Return the size of a tuple - constexpr for use as a template argument
-// See https://en.cppreference.com/w/cpp/utility/tuple/tuple_size
-template<class Tuple>
-constexpr std::size_t tuple_size() {
-    return std::tuple_size<typename std::remove_reference<Tuple>::type>::value;
-}
-
-template<class Tuple>
-using make_tuple_idxs = make_index_sequence<tuple_size<Tuple>()>;
-
-// C++17 compatibility
-// See https://en.cppreference.com/w/cpp/utility/apply
-template <class F, class Tuple, std::size_t... I>
-constexpr auto apply_impl(F&& f, Tuple&& t, index_sequence<I...>)
-    -> decltype(std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...))
+namespace ApprovalTests
 {
-    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
-}
+    namespace CartesianProduct
+    {
+        namespace Detail
+        {
 
-template <class F, class Tuple>
-auto apply(F&& f, Tuple&& t)
-    -> decltype(apply_impl(std::forward<F>(f), std::forward<Tuple>(t), make_tuple_idxs<Tuple>{}))
-{
-    apply_impl(std::forward<F>(f), std::forward<Tuple>(t), make_tuple_idxs<Tuple>{});
-}
-// End of C++17 compatibility
+            // C++14 compatibility
+            // See https://en.cppreference.com/w/cpp/types/enable_if
+            template <bool B, class T = void>
+            using enable_if_t = typename std::enable_if<B, T>::type;
 
-template <class Tuple, class F, std::size_t... Is>
-void for_each_impl(Tuple&& t, F&& f, index_sequence<Is...>) {
-    (void)std::initializer_list<int>{
-        (std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t))), 0)...
-    };
-}
+            // See https://en.cppreference.com/w/cpp/utility/integer_sequence
+            template <std::size_t... Is> struct index_sequence
+            {
+            };
 
-template <class Tuple, class F>
-void for_each(Tuple&& t, F&& f) {
-    for_each_impl(std::forward<Tuple>(t), std::forward<F>(f), make_tuple_idxs<Tuple>{});
-}
+            template <std::size_t N, std::size_t... Is>
+            struct make_index_sequence
+                : make_index_sequence<N - 1, N - 1, Is...>
+            {
+            };
 
-template<class Tuple, class F, std::size_t... Is>
-auto transform_impl(Tuple&& t, F&& f, index_sequence<Is...>)
-    -> decltype(std::make_tuple(std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t)))...))
-{
-    return std::make_tuple(std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t)))...);
-}
+            template <std::size_t... Is>
+            struct make_index_sequence<0, Is...> : index_sequence<Is...>
+            {
+            };
+            // End of C++14 compatibility
 
-template<class F, class Tuple>
-auto transform(Tuple&& t, F&& f = {})
-    -> decltype(transform_impl(std::forward<Tuple>(t), std::forward<F>(f), make_tuple_idxs<Tuple>{}))
-{
-    return transform_impl(std::forward<Tuple>(t), std::forward<F>(f), make_tuple_idxs<Tuple>{});
-}
+            // Return the size of a tuple - constexpr for use as a template argument
+            // See https://en.cppreference.com/w/cpp/utility/tuple/tuple_size
+            template <class Tuple> constexpr std::size_t tuple_size()
+            {
+                return std::tuple_size<
+                    typename std::remove_reference<Tuple>::type>::value;
+            }
 
-template<class Predicate>
-struct find_if_body {
-    const Predicate& pred;
-    std::size_t& index;
-    std::size_t currentIndex = 0;
-    bool found = false;
+            template <class Tuple>
+            using make_tuple_idxs = make_index_sequence<tuple_size<Tuple>()>;
 
-    find_if_body(const Predicate& p, std::size_t& i) : pred(p), index(i) {}
+            // C++17 compatibility
+            // See https://en.cppreference.com/w/cpp/utility/apply
+            template <class F, class Tuple, std::size_t... I>
+            constexpr auto apply_impl(F&& f, Tuple&& t, index_sequence<I...>)
+                -> decltype(
+                    std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...))
+            {
+                return std::forward<F>(f)(
+                    std::get<I>(std::forward<Tuple>(t))...);
+            }
 
-    template<typename T>
-    void operator()(T&& value) {
-        if (found) return;
-        if (pred(std::forward<T>(value))) {
-            index = currentIndex;
-            found = true;
+            template <class F, class Tuple>
+            auto apply(F&& f, Tuple&& t)
+                -> decltype(apply_impl(std::forward<F>(f),
+                                       std::forward<Tuple>(t),
+                                       make_tuple_idxs<Tuple>{}))
+            {
+                apply_impl(std::forward<F>(f),
+                           std::forward<Tuple>(t),
+                           make_tuple_idxs<Tuple>{});
+            }
+            // End of C++17 compatibility
+
+            template <class Tuple, class F, std::size_t... Is>
+            void for_each_impl(Tuple&& t, F&& f, index_sequence<Is...>)
+            {
+                (void)std::initializer_list<int>{
+                    (std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t))),
+                     0)...};
+            }
+
+            template <class Tuple, class F> void for_each(Tuple&& t, F&& f)
+            {
+                for_each_impl(std::forward<Tuple>(t),
+                              std::forward<F>(f),
+                              make_tuple_idxs<Tuple>{});
+            }
+
+            template <class Tuple, class F, std::size_t... Is>
+            auto transform_impl(Tuple&& t, F&& f, index_sequence<Is...>)
+                -> decltype(std::make_tuple(std::forward<F>(f)(
+                    std::get<Is>(std::forward<Tuple>(t)))...))
+            {
+                return std::make_tuple(std::forward<F>(f)(
+                    std::get<Is>(std::forward<Tuple>(t)))...);
+            }
+
+            template <class F, class Tuple>
+            auto transform(Tuple&& t, F&& f = {})
+                -> decltype(transform_impl(std::forward<Tuple>(t),
+                                           std::forward<F>(f),
+                                           make_tuple_idxs<Tuple>{}))
+            {
+                return transform_impl(std::forward<Tuple>(t),
+                                      std::forward<F>(f),
+                                      make_tuple_idxs<Tuple>{});
+            }
+
+            template <class Predicate> struct find_if_body
+            {
+                const Predicate& pred;
+                std::size_t& index;
+                std::size_t currentIndex = 0;
+                bool found = false;
+
+                find_if_body(const Predicate& p, std::size_t& i)
+                    : pred(p), index(i)
+                {
+                }
+
+                template <typename T> void operator()(T&& value)
+                {
+                    if (found)
+                        return;
+                    if (pred(std::forward<T>(value)))
+                    {
+                        index = currentIndex;
+                        found = true;
+                    }
+                    ++currentIndex;
+                }
+            };
+
+            template <class Predicate, class Tuple>
+            std::size_t find_if(Tuple&& tuple, Predicate pred = {})
+            {
+                std::size_t idx = tuple_size<Tuple>();
+                for_each(std::forward<Tuple>(tuple),
+                         find_if_body<Predicate>(pred, idx));
+                return idx;
+            }
+
+            template <class Predicate, class Tuple>
+            bool any_of(Tuple&& tuple, Predicate pred = {})
+            {
+                return find_if(std::forward<Tuple>(tuple), pred) !=
+                       tuple_size<Tuple>();
+            }
+
+            struct is_range_empty
+            {
+                template <class T> bool operator()(const T& range) const
+                {
+                    using std::begin;
+                    using std::end;
+                    return begin(range) == end(range);
+                }
+            };
+
+            // Transform an iterator into a value reference which will then be passed to the visitor function:
+            struct dereference_iterator
+            {
+                template <class It>
+                auto operator()(It&& it) const
+                    -> decltype(*std::forward<It>(it))
+                {
+                    return *std::forward<It>(it);
+                }
+            };
+
+            // Increment outermost iterator. If it reaches its end, we're finished and do nothing.
+            template <class Its, std::size_t I = tuple_size<Its>() - 1>
+            enable_if_t<I == 0>
+            increment_iterator(Its& it, const Its&, const Its&)
+            {
+                ++std::get<I>(it);
+            }
+
+            // Increment inner iterator. If it reaches its end, we reset it and increment the previous iterator.
+            template <class Its, std::size_t I = tuple_size<Its>() - 1>
+            enable_if_t<I != 0>
+            increment_iterator(Its& its, const Its& begins, const Its& ends)
+            {
+                if (++std::get<I>(its) == std::get<I>(ends))
+                {
+                    std::get<I>(its) = std::get<I>(begins);
+                    increment_iterator<Its, I - 1>(its, begins, ends);
+                }
+            }
+        } // namespace Detail
+
+        // This is what actually loops over all the containers, one element at a time
+        // It is called with a template type F that writes the inputs, and runs the converter, which writes the result(s)
+        // all for one set of container values - when called by verifyAllCombinations()
+        // More generally, F must have an operator() that acts on one set of input values.
+        template <class F, class... Ranges>
+        void cartesian_product(F&& f, const Ranges&... ranges)
+        {
+            using std::begin;
+            using std::end;
+
+            if (Detail::any_of<Detail::is_range_empty>(
+                    std::forward_as_tuple(ranges...)))
+                return;
+
+            const auto begins = std::make_tuple(begin(ranges)...);
+            const auto ends = std::make_tuple(end(ranges)...);
+
+            for (auto its = begins; std::get<0>(its) != std::get<0>(ends);
+                 Detail::increment_iterator(its, begins, ends))
+            {
+                // Command-clicking on transform in CLion 2019.2.1 hangs with CLion with high CPU
+                // 'Use clang tidy' is turned off.
+                // Power-save turned on.
+                // Mac
+                Detail::apply(
+                    std::forward<F>(f),
+                    Detail::transform<Detail::dereference_iterator>(its));
+            }
         }
-        ++currentIndex;
-    }
-};
-
-template<class Predicate, class Tuple>
-std::size_t find_if(Tuple&& tuple, Predicate pred = {}) {
-    std::size_t idx = tuple_size<Tuple>();
-    for_each(std::forward<Tuple>(tuple), find_if_body<Predicate>(pred, idx));
-    return idx;
-}
-
-template<class Predicate, class Tuple>
-bool any_of(Tuple&& tuple, Predicate pred = {}) {
-    return find_if(std::forward<Tuple>(tuple), pred) != tuple_size<Tuple>();
-}
-
-struct is_range_empty {
-    template<class T>
-    bool operator()(const T& range) const {
-        using std::begin;
-        using std::end;
-        return begin(range) == end(range);
-    }
-};
-
-// Transform an iterator into a value reference which will then be passed to the visitor function:
-struct dereference_iterator {
-    template<class It>
-    auto operator()(It&& it) const -> decltype(*std::forward<It>(it)) {
-        return *std::forward<It>(it);
-    }
-};
-
-// Increment outermost iterator. If it reaches its end, we're finished and do nothing.
-template<class Its, std::size_t I = tuple_size<Its>()-1>
-enable_if_t<I == 0>
-increment_iterator(Its& it, const Its&, const Its&) {
-    ++std::get<I>(it);
-}
-
-// Increment inner iterator. If it reaches its end, we reset it and increment the previous iterator.
-template<class Its, std::size_t I = tuple_size<Its>()-1>
-enable_if_t<I != 0>
-increment_iterator(Its& its, const Its& begins, const Its& ends) {
-    if (++std::get<I>(its) == std::get<I>(ends)) {
-        std::get<I>(its) = std::get<I>(begins);
-        increment_iterator<Its, I-1>(its, begins, ends);
-    }
-}
-} // namespace Detail
-
-// This is what actually loops over all the containers, one element at a time
-// It is called with a template type F that writes the inputs, and runs the converter, which writes the result(s)
-// all for one set of container values - when called by verifyAllCombinations()
-// More generally, F must have an operator() that acts on one set of input values.
-template<class F, class... Ranges>
-void cartesian_product(F&& f, const Ranges&... ranges) {
-    using std::begin;
-    using std::end;
-
-    if (Detail::any_of<Detail::is_range_empty>(std::forward_as_tuple(ranges...)))
-        return;
-
-    const auto begins = std::make_tuple(begin(ranges)...);
-    const auto ends = std::make_tuple(end(ranges)...);
-
-    for (auto its = begins; std::get<0>(its) != std::get<0>(ends); Detail::increment_iterator(its, begins, ends)) {
-        // Command-clicking on transform in CLion 2019.2.1 hangs with CLion with high CPU
-        // 'Use clang tidy' is turned off.
-        // Power-save turned on.
-        // Mac
-        Detail::apply(std::forward<F>(f), Detail::transform<Detail::dereference_iterator>(its));
-    }
-}
-} // namespace CartesianProduct
+    } // namespace CartesianProduct
 } // namespace ApprovalTests
 
 #endif

--- a/ApprovalTests/utilities/ExceptionCollector.h
+++ b/ApprovalTests/utilities/ExceptionCollector.h
@@ -7,48 +7,51 @@
 #include <vector>
 #include <functional>
 
-namespace ApprovalTests {
-class ExceptionCollector
+namespace ApprovalTests
 {
-    std::vector<std::string> exceptionMessages;
+    class ExceptionCollector
+    {
+        std::vector<std::string> exceptionMessages;
 
-public:
-    void gather(std::function<void(void)> functionThatThrows)
-    {
-        try
+    public:
+        void gather(std::function<void(void)> functionThatThrows)
         {
-            functionThatThrows();
-        }
-        catch(const std::exception& e)
-        {
-            exceptionMessages.emplace_back(e.what());
-        }
-    }
-    ~ExceptionCollector()
-    {
-        if ( ! exceptionMessages.empty())
-        {
-            exceptionMessages.emplace_back("ERROR: Calling code forgot to call exceptionCollector.release()");
-        }
-        release();
-    }
-
-    void release()
-    {
-        if (! exceptionMessages.empty())
-        {
-            std::stringstream s;
-            s << exceptionMessages.size() << " exceptions were thrown:\n\n";
-            int count = 1;
-            for( const auto& error : exceptionMessages)
+            try
             {
-                s << count++ << ") " << error << '\n';
+                functionThatThrows();
             }
-            exceptionMessages.clear();
-            throw std::runtime_error(s.str());
+            catch (const std::exception& e)
+            {
+                exceptionMessages.emplace_back(e.what());
+            }
         }
-    }
-};
+        ~ExceptionCollector()
+        {
+            if (!exceptionMessages.empty())
+            {
+                exceptionMessages.emplace_back(
+                    "ERROR: Calling code forgot to call "
+                    "exceptionCollector.release()");
+            }
+            release();
+        }
+
+        void release()
+        {
+            if (!exceptionMessages.empty())
+            {
+                std::stringstream s;
+                s << exceptionMessages.size() << " exceptions were thrown:\n\n";
+                int count = 1;
+                for (const auto& error : exceptionMessages)
+                {
+                    s << count++ << ") " << error << '\n';
+                }
+                exceptionMessages.clear();
+                throw std::runtime_error(s.str());
+            }
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_EXCEPTIONCOLLECTOR_H

--- a/ApprovalTests/utilities/FileUtils.h
+++ b/ApprovalTests/utilities/FileUtils.h
@@ -9,48 +9,61 @@
 #include <sys/stat.h>
 #include "ApprovalTests/writers/StringWriter.h"
 
-namespace ApprovalTests {
-class FileUtils {
-public:
-    static bool fileExists(const std::string& path)
+namespace ApprovalTests
+{
+    class FileUtils
     {
-        struct stat info{};
-        return stat( path.c_str(), &info ) == 0;
-    }
-
-    static int fileSize(const std::string& path) {
-        struct stat statbuf{};
-        int stat_ok = stat(path.c_str(), &statbuf);
-
-        if (stat_ok == -1) {
-            return -1;
-        }
-
-        return int(statbuf.st_size);
-    }
-
-    static void ensureFileExists(const std::string& fullFilePath) {
-        if (!fileExists(fullFilePath)) {
-            StringWriter s("", "");
-            s.write(fullFilePath);
-        }
-    }
-
-    static std::string getExtensionWithDot(const std::string& filePath) {
-        std::size_t found = filePath.find_last_of('.');
-        return filePath.substr(found);
-    }
-
-    static void writeToFile(const std::string& filePath, const std::string& content)
-    {
-        std::ofstream out(filePath.c_str(), std::ios::binary | std::ofstream::out);
-        if ( ! out)
+    public:
+        static bool fileExists(const std::string& path)
         {
-            throw std::runtime_error("Unable to write file: " + filePath);
+            struct stat info
+            {
+            };
+            return stat(path.c_str(), &info) == 0;
         }
-        out << content;
-    }
-};
+
+        static int fileSize(const std::string& path)
+        {
+            struct stat statbuf
+            {
+            };
+            int stat_ok = stat(path.c_str(), &statbuf);
+
+            if (stat_ok == -1)
+            {
+                return -1;
+            }
+
+            return int(statbuf.st_size);
+        }
+
+        static void ensureFileExists(const std::string& fullFilePath)
+        {
+            if (!fileExists(fullFilePath))
+            {
+                StringWriter s("", "");
+                s.write(fullFilePath);
+            }
+        }
+
+        static std::string getExtensionWithDot(const std::string& filePath)
+        {
+            std::size_t found = filePath.find_last_of('.');
+            return filePath.substr(found);
+        }
+
+        static void writeToFile(const std::string& filePath,
+                                const std::string& content)
+        {
+            std::ofstream out(filePath.c_str(),
+                              std::ios::binary | std::ofstream::out);
+            if (!out)
+            {
+                throw std::runtime_error("Unable to write file: " + filePath);
+            }
+            out << content;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_FILEUTILS_H

--- a/ApprovalTests/utilities/FileUtilsSystemSpecific.h
+++ b/ApprovalTests/utilities/FileUtilsSystemSpecific.h
@@ -3,23 +3,34 @@
 
 #include "SystemUtils.h"
 
-namespace ApprovalTests {
-class FileUtilsSystemSpecific
+namespace ApprovalTests
 {
-public:
-    static std::string getCommandLineForCopy(const std::string& source, const std::string& destination, bool isWindows)
+    class FileUtilsSystemSpecific
     {
-        if (isWindows) {
-            return std::string("copy /Y ") + "\"" + source + "\" \"" + destination + "\"";
-        } else {
-            return std::string("cp ") + "\"" + source + "\" \"" + destination + "\"";
+    public:
+        static std::string getCommandLineForCopy(const std::string& source,
+                                                 const std::string& destination,
+                                                 bool isWindows)
+        {
+            if (isWindows)
+            {
+                return std::string("copy /Y ") + "\"" + source + "\" \"" +
+                       destination + "\"";
+            }
+            else
+            {
+                return std::string("cp ") + "\"" + source + "\" \"" +
+                       destination + "\"";
+            }
         }
-    }
 
-    static void copyFile(const std::string& source, const std::string& destination )
-    {
-        system( getCommandLineForCopy(source, destination, SystemUtils::isWindowsOs()).c_str() );
-    }
-};
+        static void copyFile(const std::string& source,
+                             const std::string& destination)
+        {
+            system(getCommandLineForCopy(
+                       source, destination, SystemUtils::isWindowsOs())
+                       .c_str());
+        }
+    };
 }
 #endif

--- a/ApprovalTests/utilities/MachineBlocker.h
+++ b/ApprovalTests/utilities/MachineBlocker.h
@@ -5,36 +5,39 @@
 #include <utility>
 #include "SystemUtils.h"
 
-namespace ApprovalTests {
-class MachineBlocker : public Blocker
+namespace ApprovalTests
 {
-private:
-    std::string machineName;
-    bool block;
-
-    MachineBlocker() = delete;
-
-public:
-    MachineBlocker(std::string machineName, bool block ) : machineName(std::move(machineName)), block(block)
+    class MachineBlocker : public Blocker
     {
-    }
+    private:
+        std::string machineName;
+        bool block;
 
-    static MachineBlocker onMachineNamed( const std::string& machineName )
-    {
-        return MachineBlocker(machineName, true);
-    }
+        MachineBlocker() = delete;
 
-    static MachineBlocker onMachinesNotNamed( const std::string& machineName )
-    {
-        return MachineBlocker(machineName, false);
-    }
+    public:
+        MachineBlocker(std::string machineName, bool block)
+            : machineName(std::move(machineName)), block(block)
+        {
+        }
 
-    virtual bool isBlockingOnThisMachine() const override
-    {
-        const auto isMachine = (SystemUtils::getMachineName() == machineName);
-        return isMachine == block;
-    }
-};
+        static MachineBlocker onMachineNamed(const std::string& machineName)
+        {
+            return MachineBlocker(machineName, true);
+        }
+
+        static MachineBlocker onMachinesNotNamed(const std::string& machineName)
+        {
+            return MachineBlocker(machineName, false);
+        }
+
+        virtual bool isBlockingOnThisMachine() const override
+        {
+            const auto isMachine =
+                (SystemUtils::getMachineName() == machineName);
+            return isMachine == block;
+        }
+    };
 }
 
 #endif //APPROVALTESTS_CPP_MACHINEBLOCKER_H

--- a/ApprovalTests/utilities/Macros.h
+++ b/ApprovalTests/utilities/Macros.h
@@ -4,12 +4,16 @@
 // Use this in places where we have parameters that are sometimes unused,
 // e.g. because of #if
 // See https://stackoverflow.com/a/1486931/104370
-#define APPROVAL_TESTS_UNUSED(expr) do { (void)(expr); } while (0)
+#define APPROVAL_TESTS_UNUSED(expr)                                            \
+    do                                                                         \
+    {                                                                          \
+        (void)(expr);                                                          \
+    } while (0)
 
 #if __cplusplus >= 201703L
-    #define APPROVAL_TESTS_NO_DISCARD [[nodiscard]]
+#define APPROVAL_TESTS_NO_DISCARD [[nodiscard]]
 #else
-    #define APPROVAL_TESTS_NO_DISCARD
+#define APPROVAL_TESTS_NO_DISCARD
 #endif
 
 #endif //APPROVALTESTS_CPP_MACROS_H

--- a/ApprovalTests/utilities/StringUtils.h
+++ b/ApprovalTests/utilities/StringUtils.h
@@ -7,49 +7,57 @@
 #include <algorithm>
 #include <sstream>
 
-namespace ApprovalTests {
-class StringUtils
+namespace ApprovalTests
 {
-public:
-    static std::string replaceAll(std::string inText, const std::string& find, const std::string& replaceWith) {
-        size_t start_pos = 0;
-        while ((start_pos = inText.find(find, start_pos)) != std::string::npos) {
-            inText.replace(start_pos, find.length(), replaceWith);
-            start_pos += replaceWith.length(); // Handles case where 'to' is a substring of 'from'
-        }
-        return inText;
-    }
-
-    static bool contains(const std::string& inText, const std::string& find)
+    class StringUtils
     {
-        return inText.find(find, 0) != std::string::npos;
-    }
-
-    static std::string toLower(std::string inText)
-    {
-        std::string copy(inText);
-        std::transform(inText.begin(), inText.end(), copy.begin(),
-          [](char c){ return static_cast<char>(tolower(c)); });
-        return copy;
-    }
-
-    static bool endsWith(std::string value, std::string ending)
-    {
-        if (ending.size() > value.size())
+    public:
+        static std::string replaceAll(std::string inText,
+                                      const std::string& find,
+                                      const std::string& replaceWith)
         {
-            return false;
+            size_t start_pos = 0;
+            while ((start_pos = inText.find(find, start_pos)) !=
+                   std::string::npos)
+            {
+                inText.replace(start_pos, find.length(), replaceWith);
+                start_pos +=
+                    replaceWith
+                        .length(); // Handles case where 'to' is a substring of 'from'
+            }
+            return inText;
         }
-        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-    }
 
-    template<typename T>
-    static std::string toString(const T& contents)
-    {
-        std::stringstream s;
-        s << contents;
-        return s.str();
-    }
+        static bool contains(const std::string& inText, const std::string& find)
+        {
+            return inText.find(find, 0) != std::string::npos;
+        }
 
-};
+        static std::string toLower(std::string inText)
+        {
+            std::string copy(inText);
+            std::transform(
+                inText.begin(), inText.end(), copy.begin(), [](char c) {
+                    return static_cast<char>(tolower(c));
+                });
+            return copy;
+        }
+
+        static bool endsWith(std::string value, std::string ending)
+        {
+            if (ending.size() > value.size())
+            {
+                return false;
+            }
+            return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+        }
+
+        template <typename T> static std::string toString(const T& contents)
+        {
+            std::stringstream s;
+            s << contents;
+            return s.str();
+        }
+    };
 }
 #endif //APPROVALTESTS_CPP_STRINGUTILS_H

--- a/ApprovalTests/utilities/WinMinGWUtils.h
+++ b/ApprovalTests/utilities/WinMinGWUtils.h
@@ -9,17 +9,16 @@
 
 #ifdef APPROVAL_TESTS_MINGW
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <sec_api/stdlib_s.h> /* errno_t, size_t */
 
-errno_t getenv_s(
-    size_t     *ret_required_buf_size,
-    char       *buf,
-    size_t      buf_size_in_bytes,
-    const char *name
-);
+    errno_t getenv_s(size_t* ret_required_buf_size,
+                     char* buf,
+                     size_t buf_size_in_bytes,
+                     const char* name);
 
 #ifdef __cplusplus
 }

--- a/ApprovalTests/writers/ExistingFile.h
+++ b/ApprovalTests/writers/ExistingFile.h
@@ -1,27 +1,36 @@
 #ifndef APPROVALTESTS_CPP_EXISTINGFILE_H
 #define APPROVALTESTS_CPP_EXISTINGFILE_H
 
-
 #include <string>
 #include <utility>
 #include "ApprovalTests/core/ApprovalWriter.h"
 #include "ApprovalTests/utilities/FileUtils.h"
 
-namespace ApprovalTests {
-class ExistingFile : public ApprovalWriter{
-    std::string filePath;
-public:
-    explicit ExistingFile(std::string filePath) : filePath(std::move(filePath)){}
-    virtual std::string getFileExtensionWithDot() const override {
-        return FileUtils::getExtensionWithDot(filePath);
-    }
-    virtual void write(std::string /*path*/) const override {
-        // do nothing
-    }
-    virtual void cleanUpReceived(std::string /*receivedPath*/) const override {
-        // do nothing
-    }
-};
+namespace ApprovalTests
+{
+    class ExistingFile : public ApprovalWriter
+    {
+        std::string filePath;
+
+    public:
+        explicit ExistingFile(std::string filePath)
+            : filePath(std::move(filePath))
+        {
+        }
+        virtual std::string getFileExtensionWithDot() const override
+        {
+            return FileUtils::getExtensionWithDot(filePath);
+        }
+        virtual void write(std::string /*path*/) const override
+        {
+            // do nothing
+        }
+        virtual void
+            cleanUpReceived(std::string /*receivedPath*/) const override
+        {
+            // do nothing
+        }
+    };
 }
 
 #endif

--- a/ApprovalTests/writers/StringWriter.h
+++ b/ApprovalTests/writers/StringWriter.h
@@ -7,43 +7,46 @@
 #include <utility>
 #include "ApprovalTests/core/ApprovalWriter.h"
 
-namespace ApprovalTests {
-class StringWriter : public ApprovalWriter
+namespace ApprovalTests
 {
-private:
-    std::string s;
-    std::string ext;
-
-public:
-    explicit StringWriter( std::string contents, std::string fileExtensionWithDot = ".txt" )
-        : s(std::move(contents)), ext(std::move(fileExtensionWithDot)) {}
-
-    std::string getFileExtensionWithDot() const override
+    class StringWriter : public ApprovalWriter
     {
-        return ext;
-    }
+    private:
+        std::string s;
+        std::string ext;
 
-    void write( std::string path ) const override
-    {
-        std::ofstream out( path.c_str(), std::ofstream::out );
-        if ( ! out)
+    public:
+        explicit StringWriter(std::string contents,
+                              std::string fileExtensionWithDot = ".txt")
+            : s(std::move(contents)), ext(std::move(fileExtensionWithDot))
         {
-            throw std::runtime_error("Unable to write file: " + path);
         }
-        this->Write( out );
-        out.close();
-    }
 
-    void Write( std::ostream &out ) const
-    {
-        out << s << "\n";
-    }
+        std::string getFileExtensionWithDot() const override
+        {
+            return ext;
+        }
 
-    virtual void cleanUpReceived(std::string receivedPath) const override {
-        remove(receivedPath.c_str());
-    }
+        void write(std::string path) const override
+        {
+            std::ofstream out(path.c_str(), std::ofstream::out);
+            if (!out)
+            {
+                throw std::runtime_error("Unable to write file: " + path);
+            }
+            this->Write(out);
+            out.close();
+        }
 
+        void Write(std::ostream& out) const
+        {
+            out << s << "\n";
+        }
 
-};
+        virtual void cleanUpReceived(std::string receivedPath) const override
+        {
+            remove(receivedPath.c_str());
+        }
+    };
 }
 #endif

--- a/examples/catch2_existing_main/main.cpp
+++ b/examples/catch2_existing_main/main.cpp
@@ -4,10 +4,10 @@
 #include "ApprovalTests.hpp"
 // end-snippet
 
-int main( int argc, char* argv[] )
+int main(int argc, char* argv[])
 {
     // your existing setup...
-    int result = Catch::Session().run( argc, argv );
+    int result = Catch::Session().run(argc, argv);
     // your existing clean-up...
     return result;
 }

--- a/examples/googletest_existing_main/GoogleTestApprovalsTests.cpp
+++ b/examples/googletest_existing_main/GoogleTestApprovalsTests.cpp
@@ -9,6 +9,7 @@ TEST(GoogleTestApprovalsTests, TestStreamableObject)
 TEST(GoogleTestApprovalsTests, SpecificReporter)
 {
     // begin-snippet: basic_approval_with_reporter
-    ApprovalTests::Approvals::verify("text to be verified", ApprovalTests::Windows::AraxisMergeReporter());
+    ApprovalTests::Approvals::verify(
+        "text to be verified", ApprovalTests::Windows::AraxisMergeReporter());
     // end-snippet
 }

--- a/examples/googletest_existing_main/main.cpp
+++ b/examples/googletest_existing_main/main.cpp
@@ -8,7 +8,7 @@
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    
+
     // 2. Add this line to your main:
     ApprovalTests::initializeApprovalTestsForGoogleTests();
 
@@ -18,6 +18,7 @@ int main(int argc, char** argv)
 
 // begin-snippet: do_not_report_on_named_machine
 // main.cpp
-auto frontLoadedReportDisposer = ApprovalTests::Approvals::useAsFrontLoadedReporter(
-    ApprovalTests::BlockingReporter::onMachineNamed("MyCIMachineName") );
+auto frontLoadedReportDisposer =
+    ApprovalTests::Approvals::useAsFrontLoadedReporter(
+        ApprovalTests::BlockingReporter::onMachineNamed("MyCIMachineName"));
 // end-snippet

--- a/tests/Catch2_Tests/ApprovalTests.hpp
+++ b/tests/Catch2_Tests/ApprovalTests.hpp
@@ -6,5 +6,4 @@
 #include "ApprovalTests/integrations/catch/Catch2Approvals.h"
 #include "ApprovalTests/Approvals.h"
 
-
 #endif //APPROVALTESTS_CPP_APPROVALTESTS_H

--- a/tests/Catch2_Tests/ApprovalsTests.cpp
+++ b/tests/Catch2_Tests/ApprovalsTests.cpp
@@ -5,11 +5,13 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("YouCanVerifyText") {
+TEST_CASE("YouCanVerifyText")
+{
     Approvals::verify("My objects!");
 }
 
-TEST_CASE("TestStreamableObject") {
+TEST_CASE("TestStreamableObject")
+{
     Approvals::verify(42);
 }
 
@@ -19,12 +21,15 @@ public:
     NonCopyable() = default;
     NonCopyable(const NonCopyable& x) = delete; // prevent copy construction
 
-    friend std::ostream &operator<<(std::ostream &os, const NonCopyable &/*copyable*/) {
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const NonCopyable& /*copyable*/)
+    {
         return os << 999;
     }
 };
 
-TEST_CASE("TestNonCopyableStreamableObject") {
+TEST_CASE("TestNonCopyableStreamableObject")
+{
     NonCopyable object;
     Approvals::verify(object);
 }
@@ -45,44 +50,41 @@ NonStreamablePoint getPoint()
 
 TEST_CASE("YouCanVerifyWithConverterLambda")
 {
-    Approvals::verify(
-        getPoint(),
-        [](const auto& p, auto& os)
-        {
-            os << "[x: " << p.x << " y: " << p.y << "]";
-        });
+    Approvals::verify(getPoint(), [](const auto& p, auto& os) {
+        os << "[x: " << p.x << " y: " << p.y << "]";
+    });
 }
 
 // ==============================================================
 
 struct FormatNonStreamablePoint
 {
-    explicit FormatNonStreamablePoint(const NonStreamablePoint& point) : point(point)
+    explicit FormatNonStreamablePoint(const NonStreamablePoint& point)
+        : point(point)
     {
     }
 
     const NonStreamablePoint& point;
 
-    friend std::ostream &operator<<(std::ostream &os, const FormatNonStreamablePoint &wrapper)
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const FormatNonStreamablePoint& wrapper)
     {
-        os << "(x,y) = (" <<
-           wrapper.point.x << "," <<
-           wrapper.point.y << ")";
+        os << "(x,y) = (" << wrapper.point.x << "," << wrapper.point.y << ")";
         return os;
     }
 };
 
 TEST_CASE("YouCanVerifyWithConverterWrapperClass")
 {
-    Approvals::verify(
-        getPoint(),
-        [](auto r, auto& os){os << FormatNonStreamablePoint(r);}
-    );
+    Approvals::verify(getPoint(), [](auto r, auto& os) {
+        os << FormatNonStreamablePoint(r);
+    });
 }
 
 // ==============================================================
 
-std::ostream& customToStreamFunction(std::ostream &os, const NonStreamablePoint& point)
+std::ostream& customToStreamFunction(std::ostream& os,
+                                     const NonStreamablePoint& point)
 {
     os << point.x << "," << point.y;
     return os;
@@ -90,22 +92,21 @@ std::ostream& customToStreamFunction(std::ostream &os, const NonStreamablePoint&
 
 TEST_CASE("YouCanVerifyWithConverterWrapperFunction")
 {
-    Approvals::verify(
-        getPoint(),
-        [](auto r, auto& os){ customToStreamFunction(os, r);}
-    );
+    Approvals::verify(getPoint(),
+                      [](auto r, auto& os) { customToStreamFunction(os, r); });
 }
 
 // ==============================================================
 
 TEST_CASE("VerifyingException")
 {
-    Approvals::verifyExceptionMessage([](){throw std::runtime_error("Here is my exception message");});
+    Approvals::verifyExceptionMessage(
+        []() { throw std::runtime_error("Here is my exception message"); });
 }
 
 TEST_CASE("VerifyingNoException")
 {
     // begin-snippet: verify_exception_message_example
-    Approvals::verifyExceptionMessage([](){/* your code goes here */});
+    Approvals::verifyExceptionMessage([]() { /* your code goes here */ });
     // end-snippet
 }

--- a/tests/Catch2_Tests/CombinationTests.cpp
+++ b/tests/Catch2_Tests/CombinationTests.cpp
@@ -9,20 +9,24 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("YouCanVerifyCombinationsOf1") {
+TEST_CASE("YouCanVerifyCombinationsOf1")
+{
     std::vector<std::string> words{"hello", "world"};
-    CombinationApprovals::verifyAllCombinations([](const std::string& s){return s + "!";}, words);
+    CombinationApprovals::verifyAllCombinations(
+        [](const std::string& s) { return s + "!"; }, words);
 }
 
-TEST_CASE("YouCanVerifyCombinationsOf1WithTemplateParameters") {
+TEST_CASE("YouCanVerifyCombinationsOf1WithTemplateParameters")
+{
     std::vector<std::string> words{"hello", "world"};
-    CombinationApprovals::verifyAllCombinations([](const std::string& s){return s + "!";}, words);
+    CombinationApprovals::verifyAllCombinations(
+        [](const std::string& s) { return s + "!"; }, words);
 }
 
 FrontLoadedReporterDisposer clearFrontLoadedReporter()
 {
     return Approvals::useAsFrontLoadedReporter(
-            BlockingReporter::onMachineNamed("safadfasdfas"));
+        BlockingReporter::onMachineNamed("safadfasdfas"));
 }
 
 TEST_CASE("YouCanVerifyCombinationsOf1Reports")
@@ -32,40 +36,50 @@ TEST_CASE("YouCanVerifyCombinationsOf1Reports")
     FakeReporter reporter;
     try
     {
-        CombinationApprovals::verifyAllCombinations(reporter, [](const std::string& s){return s + "!";}, words);
+        CombinationApprovals::verifyAllCombinations(
+            reporter, [](const std::string& s) { return s + "!"; }, words);
     }
-    catch(const ApprovalException&)
+    catch (const ApprovalException&)
     {
         // ignore
     }
     REQUIRE(reporter.called == true);
 }
 
-
 // begin-snippet: YouCanVerifyCombinationsOf2
-TEST_CASE("YouCanVerifyCombinationsOf2") {
+TEST_CASE("YouCanVerifyCombinationsOf2")
+{
     std::vector<std::string> v{"hello", "world"};
     std::vector<int> numbers{1, 2, 3};
     CombinationApprovals::verifyAllCombinations(
-            [](std::string s, int i){return std::make_pair(s, i);},
-            v,
-            numbers);
+        [](std::string s, int i) { return std::make_pair(s, i); }, v, numbers);
 }
 // end-snippet
 
-TEST_CASE("YouCanVerifyCombinationsOf9") {
+TEST_CASE("YouCanVerifyCombinationsOf9")
+{
     std::vector<std::string> letters{"a", "b"};
-    CombinationApprovals::verifyAllCombinations([](
-                                                               const std::string& s1,
-                                                               const std::string& s2,
-                                                               const std::string& s3,
-                                                               const std::string& s4,
-                                                               const std::string& s5,
-                                                               const std::string& s6,
-                                                               const std::string& s7,
-                                                               const std::string& s8,
-                                                               const std::string& s9)
-                              {return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;}, letters, letters, letters, letters, letters, letters, letters, letters, letters);
+    CombinationApprovals::verifyAllCombinations(
+        [](const std::string& s1,
+           const std::string& s2,
+           const std::string& s3,
+           const std::string& s4,
+           const std::string& s5,
+           const std::string& s6,
+           const std::string& s7,
+           const std::string& s8,
+           const std::string& s9) {
+            return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
+        },
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters);
 }
 
 TEST_CASE("YouCanVerifyCombinationsOf9Reports")
@@ -77,32 +91,58 @@ TEST_CASE("YouCanVerifyCombinationsOf9Reports")
         std::vector<std::string> letters{"a", "b"};
         CombinationApprovals::verifyAllCombinations(
             reporter,
-            [](const std::string& s1, const std::string& s2, const std::string& s3, const std::string& s4, const std::string& s5,
-               const std::string& s6, const std::string& s7, const std::string& s8, const std::string& s9)
-            {return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;},
-            letters, letters, letters, letters, letters, letters, letters, letters, letters
-        );
+            [](const std::string& s1,
+               const std::string& s2,
+               const std::string& s3,
+               const std::string& s4,
+               const std::string& s5,
+               const std::string& s6,
+               const std::string& s7,
+               const std::string& s8,
+               const std::string& s9) {
+                return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
+            },
+            letters,
+            letters,
+            letters,
+            letters,
+            letters,
+            letters,
+            letters,
+            letters,
+            letters);
     }
-    catch(const ApprovalException&)
+    catch (const ApprovalException&)
     {
         // ignore
     }
     REQUIRE(reporter.called == true);
 }
 
-
-TEST_CASE("YouCanVerifyCombinationsOf10") {
+TEST_CASE("YouCanVerifyCombinationsOf10")
+{
     std::vector<std::string> letters{"a", "b"};
-    CombinationApprovals::verifyAllCombinations([](
-                                                               const std::string& s1,
-                                                               const std::string& s2,
-                                                               const std::string& s3,
-                                                               const std::string& s4,
-                                                               const std::string& s5,
-                                                               const std::string& s6,
-                                                               const std::string& s7,
-                                                               const std::string& s8,
-                                                               const std::string& s9,
-                                                               const std::string& s10)
-                              {return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;}, letters, letters, letters, letters, letters, letters, letters, letters, letters, letters);
+    CombinationApprovals::verifyAllCombinations(
+        [](const std::string& s1,
+           const std::string& s2,
+           const std::string& s3,
+           const std::string& s4,
+           const std::string& s5,
+           const std::string& s6,
+           const std::string& s7,
+           const std::string& s8,
+           const std::string& s9,
+           const std::string& s10) {
+            return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
+        },
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters,
+        letters);
 }

--- a/tests/Catch2_Tests/PairUtilities.h
+++ b/tests/Catch2_Tests/PairUtilities.h
@@ -1,9 +1,12 @@
 #include <map>
 #include <ostream>
 
-namespace ApprovalTests {
-inline std::ostream &operator<<(std::ostream &os, const std::pair<std::string, int> &pair) {
-    os << "(" << pair.first << ", " << pair.second << ")";
-    return os;
-}
+namespace ApprovalTests
+{
+    inline std::ostream& operator<<(std::ostream& os,
+                                    const std::pair<std::string, int>& pair)
+    {
+        os << "(" << pair.first << ", " << pair.second << ")";
+        return os;
+    }
 }

--- a/tests/Catch2_Tests/StyleGuide.h
+++ b/tests/Catch2_Tests/StyleGuide.h
@@ -19,5 +19,4 @@ namespace ExampleNameSpace
     };
 }
 
-
 #endif //APPROVALTESTS_CPP_STYLEGUIDE_H

--- a/tests/Catch2_Tests/VectorTests.cpp
+++ b/tests/Catch2_Tests/VectorTests.cpp
@@ -4,22 +4,30 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("YouCanVerifyIteratorRange") {
+TEST_CASE("YouCanVerifyIteratorRange")
+{
     std::vector<std::string> v{"hello", "world"};
-    Approvals::verifyAll("FIRST LETTER", v.begin(), v.end(), [](auto s, auto& os){os << s << " => " << s[0];});
+    Approvals::verifyAll("FIRST LETTER",
+                         v.begin(),
+                         v.end(),
+                         [](auto s, auto& os) { os << s << " => " << s[0]; });
 }
 
-TEST_CASE("YouCanVerifyVectors") {
+TEST_CASE("YouCanVerifyVectors")
+{
     std::vector<std::string> v{"hello", "world"};
-    Approvals::verifyAll("FIRST LETTER", v, [](auto s, auto& os){os << s << " => " << s[0];});
+    Approvals::verifyAll(
+        "FIRST LETTER", v, [](auto s, auto& os) { os << s << " => " << s[0]; });
 }
 
-TEST_CASE("YouCanVerifyVectorsWithStandardText") {
+TEST_CASE("YouCanVerifyVectorsWithStandardText")
+{
     std::vector<std::string> v{"hello", "world"};
     Approvals::verifyAll("WORDS", v);
 }
 
-TEST_CASE("YouCanVerifyVectorsWithStandardTextNoHeader") {
+TEST_CASE("YouCanVerifyVectorsWithStandardTextNoHeader")
+{
     std::vector<std::string> v{"hello", "world"};
     Approvals::verifyAll(v);
 }

--- a/tests/Catch2_Tests/core/ApprovalExceptionTests.cpp
+++ b/tests/Catch2_Tests/core/ApprovalExceptionTests.cpp
@@ -5,18 +5,21 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("ApprovalMissingExceptionHasAMessage") {
-    ApprovalMissingException a("r.txt", "a.txt" );
-    std::string expected = "Failed Approval: \nApproval File Not Found \nFile: \"a.txt\"";
-    REQUIRE(a.what() == expected );
+TEST_CASE("ApprovalMissingExceptionHasAMessage")
+{
+    ApprovalMissingException a("r.txt", "a.txt");
+    std::string expected =
+        "Failed Approval: \nApproval File Not Found \nFile: \"a.txt\"";
+    REQUIRE(a.what() == expected);
 }
 
-TEST_CASE("ApprovalMismatchExceptionHasAMessage") {
-    ApprovalMismatchException a("r.txt", "a.txt" );
+TEST_CASE("ApprovalMismatchExceptionHasAMessage")
+{
+    ApprovalMismatchException a("r.txt", "a.txt");
     std::string expected = "Failed Approval: \n"
-            "Received does not match approved \n"
-            "Received : \"r.txt\" \n"
-            "Approved : \"a.txt\"";
+                           "Received does not match approved \n"
+                           "Received : \"r.txt\" \n"
+                           "Approved : \"a.txt\"";
     REQUIRE(a.what() == expected);
 }
 
@@ -25,7 +28,8 @@ TEST_CASE("ApprovalMissingException is thrown")
     // Important to note that QuietReporter doesn't create the missing
     // approved file
     bool exception_caught = false;
-    try {
+    try
+    {
         Approvals::verify("foo", QuietReporter());
     }
     catch (const ApprovalMissingException&)

--- a/tests/Catch2_Tests/core/FileApproverTests.cpp
+++ b/tests/Catch2_Tests/core/FileApproverTests.cpp
@@ -7,7 +7,8 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("ItVerifiesApprovedFileExists") {
+TEST_CASE("ItVerifiesApprovedFileExists")
+{
 
     ApprovalTestNamer namer;
     StringWriter writer("Hello");
@@ -17,53 +18,59 @@ TEST_CASE("ItVerifiesApprovedFileExists") {
     std::string received = namer.getReceivedFile(".txt");
 
     std::string expected = "Failed Approval: \n"
-                              "Approval File Not Found \n"
-                              "File: \"" + approved+"\"";
-    REQUIRE_THROWS_WITH(FileApprover::verify(namer, writer, reporter), expected);
+                           "Approval File Not Found \n"
+                           "File: \"" +
+                           approved + "\"";
+    REQUIRE_THROWS_WITH(FileApprover::verify(namer, writer, reporter),
+                        expected);
 
     remove(approved.c_str());
     remove(received.c_str());
 }
 
-
-TEST_CASE("ItVerifiesExistingFiles") {
+TEST_CASE("ItVerifiesExistingFiles")
+{
     ApprovalTestNamer namer;
     Approvals::verifyExistingFile(namer.getDirectory() + "../../sample.txt");
 }
 
-
-TEST_CASE("ItIgnoresLineEndingDifferences") {
+TEST_CASE("ItIgnoresLineEndingDifferences")
+{
     FileUtils::writeToFile("a.txt", "1\r\n2\n3\r\n4\r\n5");
     FileUtils::writeToFile("b.txt", "1\n2\r\n3\r\n4\n5");
     FileApprover::verify("a.txt", "b.txt");
 }
 
-
-TEST_CASE("ItComparesTheEntireFile") {
+TEST_CASE("ItComparesTheEntireFile")
+{
     FileUtils::writeToFile("a.txt", "12345");
     FileUtils::writeToFile("b.txt", "123");
-    CHECK_THROWS_AS(FileApprover::verify("a.txt", "b.txt"), ApprovalMismatchException);
+    CHECK_THROWS_AS(FileApprover::verify("a.txt", "b.txt"),
+                    ApprovalMismatchException);
 }
 
 // begin-snippet: create_custom_comparator
 class LengthComparator : public ApprovalComparator
 {
 public:
-    bool contentsAreEquivalent(std::string receivedPath, std::string approvedPath) const override
+    bool contentsAreEquivalent(std::string receivedPath,
+                               std::string approvedPath) const override
     {
-        return FileUtils::fileSize(receivedPath) == FileUtils::fileSize(approvedPath);
+        return FileUtils::fileSize(receivedPath) ==
+               FileUtils::fileSize(approvedPath);
     }
 };
 // end-snippet
 
-TEST_CASE("ItUsesCustomComparator") {
+TEST_CASE("ItUsesCustomComparator")
+{
     FileUtils::writeToFile("a.length", "12345");
     FileUtils::writeToFile("b.length", "56789");
 
     // begin-snippet: use_custom_comparator
-    auto disposer = FileApprover::registerComparatorForExtension(".length", std::make_shared<LengthComparator>());
+    auto disposer = FileApprover::registerComparatorForExtension(
+        ".length", std::make_shared<LengthComparator>());
     // end-snippet
 
     FileApprover::verify("a.length", "b.length");
 }
-

--- a/tests/Catch2_Tests/documentation/Catch2DocumentationSamples.cpp
+++ b/tests/Catch2_Tests/documentation/Catch2DocumentationSamples.cpp
@@ -29,31 +29,31 @@ struct Greeting
 
     std::string getGreetingFor(Nationality aNationality) const
     {
-        switch(aNationality)
+        switch (aNationality)
         {
-            case British:
-                return "Cheers";
-            case American:
-                return "Howdy";
-            case French:
-                return "Bonjour";
-            default:
-                return "Unknown";
+        case British:
+            return "Cheers";
+        case American:
+            return "Howdy";
+        case French:
+            return "Bonjour";
+        default:
+            return "Unknown";
         }
     }
 
     std::string getNationality() const
     {
-        switch(nationality)
+        switch (nationality)
         {
-            case British:
-                return "British";
-            case American:
-                return "American";
-            case French:
-                return "French";
-            default:
-                return "Unknown";
+        case British:
+            return "British";
+        case American:
+            return "American";
+        case French:
+            return "French";
+        default:
+            return "Unknown";
         }
     }
 };
@@ -65,8 +65,9 @@ TEST_CASE("MultipleOutputFiles-DataDriven")
     // Note: For data as small as this, in practice we would recommend passing the
     // greetings container in to Approvals::verifyAll(), with a lambda to format the output,
     // in order to write all data to a single file.
-    std::vector<Greeting> greetings{ Greeting(British), Greeting(American), Greeting(French) };
-    for(auto greeting: greetings)
+    std::vector<Greeting> greetings{
+        Greeting(British), Greeting(American), Greeting(French)};
+    for (auto greeting : greetings)
     {
         SECTION(greeting.getNationality())
         {

--- a/tests/Catch2_Tests/documentation/CombinationsSampleCode.cpp
+++ b/tests/Catch2_Tests/documentation/CombinationsSampleCode.cpp
@@ -5,15 +5,13 @@
 
 using namespace ApprovalTests;
 
-
 namespace
 {
-double
-functionThatReturnsSomethingOutputStreamable(const std::string& /*input1*/, const int input2, const double input3)
-{
-    return input2 * input3;
-}
-
+    double functionThatReturnsSomethingOutputStreamable(
+        const std::string& /*input1*/, const int input2, const double input3)
+    {
+        return input2 * input3;
+    }
 }
 
 TEST_CASE("YouCanVerifyCombinationsOf3")
@@ -24,13 +22,13 @@ TEST_CASE("YouCanVerifyCombinationsOf3")
     std::vector<double> listOfInput3s{1.1, 2.2};
     // begin-snippet: sample_combinations_of_three
     CombinationApprovals::verifyAllCombinations(
-            []( const std::string& input1, const int input2, const double input3)
-            {
-                return functionThatReturnsSomethingOutputStreamable(input1, input2, input3);
-            }, // This is the converter function
-            listOfInput1s,
-            listOfInput2s,
-            listOfInput3s);
+        [](const std::string& input1, const int input2, const double input3) {
+            return functionThatReturnsSomethingOutputStreamable(
+                input1, input2, input3);
+        }, // This is the converter function
+        listOfInput1s,
+        listOfInput2s,
+        listOfInput3s);
     // end-snippet
 }
 
@@ -42,12 +40,12 @@ TEST_CASE("YouCanVerifyCombinationsOf3WithAuto")
     std::vector<double> listOfInput3s{1.1, 2.2};
     // begin-snippet: sample_combinations_of_three_with_auto
     CombinationApprovals::verifyAllCombinations(
-            []( auto& input1, auto& input2, auto& input3)
-            {
-                return functionThatReturnsSomethingOutputStreamable(input1, input2, input3);
-            }, // This is the converter function
-            listOfInput1s,
-            listOfInput2s,
-            listOfInput3s);
+        [](auto& input1, auto& input2, auto& input3) {
+            return functionThatReturnsSomethingOutputStreamable(
+                input1, input2, input3);
+        }, // This is the converter function
+        listOfInput1s,
+        listOfInput2s,
+        listOfInput3s);
     // end-snippet
 }

--- a/tests/Catch2_Tests/documentation/OverviewExamples.cpp
+++ b/tests/Catch2_Tests/documentation/OverviewExamples.cpp
@@ -20,7 +20,7 @@ public:
         std::stringstream os;
         bool written = false;
         os << "[";
-        for(const auto& thing : contents)
+        for (const auto& thing : contents)
         {
             if (written)
             {
@@ -74,7 +74,7 @@ static Sandwich createSandwichForTest()
     return result;
 }
 
-std::ostream &operator<<(std::ostream&os, const Sandwich& sandwich)
+std::ostream& operator<<(std::ostream& os, const Sandwich& sandwich)
 {
     os << "sandwich {\n";
     os << "    bread: \"" << sandwich.bread << "\",\n";

--- a/tests/Catch2_Tests/documentation/ToStringExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringExample.cpp
@@ -5,22 +5,24 @@
 
 using namespace ApprovalTests;
 
-struct Rectangle2{
+struct Rectangle2
+{
 
-    int x,y, width, height;
+    int x, y, width, height;
 
     // begin-snippet: to_string_standard_example
-    friend std::ostream &operator<<(std::ostream &os, const Rectangle2 &rectangle) {
-        os << "[x: " << rectangle.x << " y: " << rectangle.y << " width: " << rectangle.width << " height: "
-           << rectangle.height << "]";
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const Rectangle2& rectangle)
+    {
+        os << "[x: " << rectangle.x << " y: " << rectangle.y
+           << " width: " << rectangle.width << " height: " << rectangle.height
+           << "]";
         return os;
     }
     // end-snippet
-
 };
-TEST_CASE("ToStringsAreHelpful") {
-    Rectangle2 r = {40,50,100,60};
+TEST_CASE("ToStringsAreHelpful")
+{
+    Rectangle2 r = {40, 50, 100, 60};
     Approvals::verify(r);
-
 }
-

--- a/tests/Catch2_Tests/documentation/ToStringTemplateExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringTemplateExample.cpp
@@ -5,25 +5,26 @@
 
 using namespace ApprovalTests;
 
-struct Rectangle2{
+struct Rectangle2
+{
 
-    int x,y, width, height;
+    int x, y, width, height;
 
     // Using Template instead of ostream for embedded instances where ostream aren't available
     // template implementation of output operator
     // begin-snippet: to_string_template_example
     template <class STREAM>
-    friend STREAM &operator<<(STREAM &os, const Rectangle2 &rectangle) {
-        os << "[x: " << rectangle.x << " y: " << rectangle.y << " width: " << rectangle.width << " height: "
-           << rectangle.height << "]";
+    friend STREAM& operator<<(STREAM& os, const Rectangle2& rectangle)
+    {
+        os << "[x: " << rectangle.x << " y: " << rectangle.y
+           << " width: " << rectangle.width << " height: " << rectangle.height
+           << "]";
         return os;
     }
     // end-snippet
-
 };
-TEST_CASE("ToStringTemplatesAreHelpful") {
-    Rectangle2 r = {40,50,100,60};
+TEST_CASE("ToStringTemplatesAreHelpful")
+{
+    Rectangle2 r = {40, 50, 100, 60};
     Approvals::verify(r);
-
 }
-

--- a/tests/Catch2_Tests/documentation/ToStringWrapperExample.cpp
+++ b/tests/Catch2_Tests/documentation/ToStringWrapperExample.cpp
@@ -5,77 +5,77 @@
 
 using namespace ApprovalTests;
 
-struct Rectangle3{
+struct Rectangle3
+{
 
-    int x,y, width, height;
+    int x, y, width, height;
 
-    friend std::ostream &operator<<(std::ostream &os, const Rectangle3 &rectangle) {
-        os << "[x: " << rectangle.x << " y: " << rectangle.y << " width: " << rectangle.width << " height: "
-           << rectangle.height << "]";
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const Rectangle3& rectangle)
+    {
+        os << "[x: " << rectangle.x << " y: " << rectangle.y
+           << " width: " << rectangle.width << " height: " << rectangle.height
+           << "]";
         return os;
     }
 };
 
 std::vector<Rectangle3> getRectangles()
 {
-    return
-    {
+    return {
         {4, 50, 100, 61},
         {50, 5200, 400, 62},
         {60, 3, 7, 63},
     };
 }
 
-TEST_CASE("MultipleLinesCanBeHardToRead") {
+TEST_CASE("MultipleLinesCanBeHardToRead")
+{
     // begin-snippet: verify_list
-    Approvals::verifyAll(
-        "rectangles",
-        getRectangles());
+    Approvals::verifyAll("rectangles", getRectangles());
     // end-snippet
-
 }
 
 // begin-snippet: to_string_wrapper_example
-struct FormatRectangleForMultipleLines{
+struct FormatRectangleForMultipleLines
+{
 
-    explicit FormatRectangleForMultipleLines(const Rectangle3& rectangle) : rectangle(rectangle)
+    explicit FormatRectangleForMultipleLines(const Rectangle3& rectangle)
+        : rectangle(rectangle)
     {
     }
 
     const Rectangle3& rectangle;
 
-    friend std::ostream &operator<<(std::ostream &os, const FormatRectangleForMultipleLines &wrapper) {
-        os << "(x,y,width,height) = (" <<
-           wrapper.rectangle.x << "," <<
-           wrapper.rectangle.y << "," <<
-           wrapper.rectangle.width << "," <<
-           wrapper.rectangle.height << ")";
+    friend std::ostream&
+    operator<<(std::ostream& os, const FormatRectangleForMultipleLines& wrapper)
+    {
+        os << "(x,y,width,height) = (" << wrapper.rectangle.x << ","
+           << wrapper.rectangle.y << "," << wrapper.rectangle.width << ","
+           << wrapper.rectangle.height << ")";
         return os;
     }
 };
 
-TEST_CASE("AlternativeFormattingCanBeEasyToRead") {
-    Approvals::verifyAll(
-        "rectangles",
-        getRectangles(),
-        [](auto r, auto& os){os << FormatRectangleForMultipleLines(r);}
-    );
+TEST_CASE("AlternativeFormattingCanBeEasyToRead")
+{
+    Approvals::verifyAll("rectangles", getRectangles(), [](auto r, auto& os) {
+        os << FormatRectangleForMultipleLines(r);
+    });
 }
 // end-snippet
 
-std::ostream& toStringForMultipleLines(std::ostream &os, const Rectangle3 &rectangle) {
-    os << "(x,y,width,height) = (" <<
-       rectangle.x << "," <<
-       rectangle.y << "," <<
-       rectangle.width << "," <<
-       rectangle.height << ")";
+std::ostream& toStringForMultipleLines(std::ostream& os,
+                                       const Rectangle3& rectangle)
+{
+    os << "(x,y,width,height) = (" << rectangle.x << "," << rectangle.y << ","
+       << rectangle.width << "," << rectangle.height << ")";
     return os;
 }
 
-TEST_CASE("AlternativeFormattingCanBeEasyToRead2") {
-    Approvals::verifyAll(
-        "rectangles",
-        getRectangles(),
-        [](auto r, auto& os){ toStringForMultipleLines(os, r);}
-    );
+TEST_CASE("AlternativeFormattingCanBeEasyToRead2")
+{
+    Approvals::verifyAll("rectangles", getRectangles(), [](auto r, auto& os) {
+        toStringForMultipleLines(os, r);
+    });
 }

--- a/tests/Catch2_Tests/documentation/Tutorial.cpp
+++ b/tests/Catch2_Tests/documentation/Tutorial.cpp
@@ -12,8 +12,6 @@ using namespace ApprovalTests;
 // See the tutorial at:
 //   https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/Tutorial.md#top
 
-
-
 // Maintainance note: keep the 'ApprovalTests::' - for the docs
 // begin-snippet: hello_approvals
 TEST_CASE("HelloApprovals")
@@ -26,10 +24,18 @@ TEST_CASE("HelloApprovals")
 class LibraryBook
 {
 public:
-    LibraryBook(std::string title, std::string author, int available_copies,
-                std::string language, int pages, std::string isbn) :
-                title(title), author(author), available_copies(available_copies),
-                language(language), pages(pages), isbn(isbn)
+    LibraryBook(std::string title,
+                std::string author,
+                int available_copies,
+                std::string language,
+                int pages,
+                std::string isbn)
+        : title(title)
+        , author(author)
+        , available_copies(available_copies)
+        , language(language)
+        , pages(pages)
+        , isbn(isbn)
     {
     }
     // Data public for simplicity of test demo case.
@@ -59,32 +65,37 @@ TEST_CASE("WritableBooks Does Not Compile")
 
 TEST_CASE("WritableBooks1")
 {
-    LibraryBook harry_potter(
-        "Harry Potter and the Goblet of Fire", "J.K. Rowling",
-        30, "English", 752, "978-0439139595");
+    LibraryBook harry_potter("Harry Potter and the Goblet of Fire",
+                             "J.K. Rowling",
+                             30,
+                             "English",
+                             752,
+                             "978-0439139595");
 
     // begin-snippet: printable_object_simple
-    Approvals::verify(
-        harry_potter,
-        [](const LibraryBook& b, std::ostream& os){ os << "title: " << b.title; });
+    Approvals::verify(harry_potter, [](const LibraryBook& b, std::ostream& os) {
+        os << "title: " << b.title;
+    });
     // end-snippet
 }
 
 TEST_CASE("WritableBooks2")
 {
-    LibraryBook harry_potter(
-        "Harry Potter and the Goblet of Fire", "J.K. Rowling",
-        30, "English", 752, "978-0439139595");
+    LibraryBook harry_potter("Harry Potter and the Goblet of Fire",
+                             "J.K. Rowling",
+                             30,
+                             "English",
+                             752,
+                             "978-0439139595");
 
     // begin-snippet: printable_object
-    Approvals::verify(harry_potter, [](const LibraryBook& b, std::ostream& os){
-        os <<
-        "title: " << b.title << "\n" <<
-        "author: " << b.author << "\n" <<
-        "available_copies: " << b.available_copies << "\n" <<
-        "language: " << b.language << "\n" <<
-        "pages: " << b.pages << "\n" <<
-        "isbn: " << b.isbn << "\n";
+    Approvals::verify(harry_potter, [](const LibraryBook& b, std::ostream& os) {
+        os << "title: " << b.title << "\n"
+           << "author: " << b.author << "\n"
+           << "available_copies: " << b.available_copies << "\n"
+           << "language: " << b.language << "\n"
+           << "pages: " << b.pages << "\n"
+           << "isbn: " << b.isbn << "\n";
     });
     // end-snippet
 }

--- a/tests/Catch2_Tests/main.cpp
+++ b/tests/Catch2_Tests/main.cpp
@@ -18,5 +18,6 @@ auto directory = Approvals::useApprovalsSubdirectory("approval_tests");
 // begin-snippet: use_as_default_reporter_in_main
 // main.cpp:
 #include <memory>
-auto defaultReporterDisposer = Approvals::useAsDefaultReporter(std::make_shared<DiffReporter>() );
+auto defaultReporterDisposer =
+    Approvals::useAsDefaultReporter(std::make_shared<DiffReporter>());
 // end-snippet

--- a/tests/Catch2_Tests/namers/NamerTests.cpp
+++ b/tests/Catch2_Tests/namers/NamerTests.cpp
@@ -7,27 +7,33 @@ using Catch::Matchers::EndsWith;
 
 using namespace ApprovalTests;
 
-TEST_CASE("ItCanGiveYouTheSpecName") {
+TEST_CASE("ItCanGiveYouTheSpecName")
+{
 
     ApprovalTestNamer namer;
     REQUIRE(namer.getTestName() == "ItCanGiveYouTheSpecName");
 
-    SECTION("andSectionNames") {
-        REQUIRE(namer.getTestName() == "ItCanGiveYouTheSpecName.andSectionNames");
-        SECTION("andEvenMoreSectionNames") {
-            REQUIRE(namer.getTestName() == "ItCanGiveYouTheSpecName.andSectionNames.andEvenMoreSectionNames");
+    SECTION("andSectionNames")
+    {
+        REQUIRE(namer.getTestName() ==
+                "ItCanGiveYouTheSpecName.andSectionNames");
+        SECTION("andEvenMoreSectionNames")
+        {
+            REQUIRE(namer.getTestName() ==
+                    "ItCanGiveYouTheSpecName.andSectionNames."
+                    "andEvenMoreSectionNames");
         }
     }
 }
 
-
-TEST_CASE("ItCanGiveYouTheTestFileName") {
+TEST_CASE("ItCanGiveYouTheTestFileName")
+{
     ApprovalTestNamer namer;
     REQUIRE(namer.getFileName() == "NamerTests");
 }
 
-
-TEST_CASE("TestProperNameCaseOnWindows") {
+TEST_CASE("TestProperNameCaseOnWindows")
+{
     if (SystemUtils::isWindowsOs())
     {
         ApprovalTestNamer namer;
@@ -38,8 +44,8 @@ TEST_CASE("TestProperNameCaseOnWindows") {
     }
 }
 
-
-TEST_CASE("ItCanGiveYouTheTestDirectory") {
+TEST_CASE("ItCanGiveYouTheTestDirectory")
+{
     // This should work with CaseSensitive::Yes.
     // However, it would fail when run in Visual Studio 2017 as lower-case source-file names are returned.
     // We've fixed this for filenames, but not directory names, so this test ignores case.
@@ -47,32 +53,42 @@ TEST_CASE("ItCanGiveYouTheTestDirectory") {
     auto suppress_subdirectory = Approvals::useApprovalsSubdirectory("");
     ApprovalTestNamer namer;
     auto __ = SystemUtils::getDirectorySeparator();
-    REQUIRE_THAT(namer.getDirectory(), EndsWith(__ + "Catch2_Tests" + __ + "namers" + __, Catch::CaseSensitive::No));
+    REQUIRE_THAT(namer.getDirectory(),
+                 EndsWith(__ + "Catch2_Tests" + __ + "namers" + __,
+                          Catch::CaseSensitive::No));
 }
 
-
-TEST_CASE("ItIncludesFileContextAndSpecNames") {
+TEST_CASE("ItIncludesFileContextAndSpecNames")
+{
     ApprovalTestNamer namer;
     auto __ = SystemUtils::getDirectorySeparator();
 
-    REQUIRE_THAT(namer.getApprovedFile(".txt"),
-        EndsWith(__ + "NamerTests.ItIncludesFileContextAndSpecNames.approved.txt"));
-    REQUIRE_THAT(namer.getReceivedFile(".txt"),
-        EndsWith(__ + "NamerTests.ItIncludesFileContextAndSpecNames.received.txt"));
+    REQUIRE_THAT(
+        namer.getApprovedFile(".txt"),
+        EndsWith(__ +
+                 "NamerTests.ItIncludesFileContextAndSpecNames.approved.txt"));
+    REQUIRE_THAT(
+        namer.getReceivedFile(".txt"),
+        EndsWith(__ +
+                 "NamerTests.ItIncludesFileContextAndSpecNames.received.txt"));
 }
-
 
 TEST_CASE("Clean Up Filename Transforms")
 {
-    std::vector<std::string> names = { "CleanUpFilenameTransforms", "Spaces In File \\" };
-    Approvals::verifyAll("File Names", names, [&](const std::string& name, std::ostream &s) {s << name << " => " << ApprovalTestNamer::convertToFileName(name); });
+    std::vector<std::string> names = {"CleanUpFilenameTransforms",
+                                      "Spaces In File \\"};
+    Approvals::verifyAll(
+        "File Names", names, [&](const std::string& name, std::ostream& s) {
+            s << name << " => " << ApprovalTestNamer::convertToFileName(name);
+        });
 }
 
 TEST_CASE("Use sub-directory")
 {
     auto subdirectory = Approvals::useApprovalsSubdirectory("approved_files");
     auto namer = Approvals::getDefaultNamer();
-    REQUIRE_THAT( namer->getApprovedFile(".txt"), Catch::Matchers::Contains( "approved_files" ) );
+    REQUIRE_THAT(namer->getApprovedFile(".txt"),
+                 Catch::Matchers::Contains("approved_files"));
 }
 
 TEST_CASE("Use sub-directories clean to previous results")
@@ -82,14 +98,17 @@ TEST_CASE("Use sub-directories clean to previous results")
 
     {
         auto subdirectory2 = Approvals::useApprovalsSubdirectory("inner");
-        REQUIRE_THAT( namer->getApprovedFile(".txt"), Catch::Matchers::Contains( "inner" ) );
+        REQUIRE_THAT(namer->getApprovedFile(".txt"),
+                     Catch::Matchers::Contains("inner"));
     }
 
-    REQUIRE_THAT( namer->getApprovedFile(".txt"), Catch::Matchers::Contains( "outer" ) );
+    REQUIRE_THAT(namer->getApprovedFile(".txt"),
+                 Catch::Matchers::Contains("outer"));
 }
 
 TEST_CASE("Tags not included in file name", "[tag_name]")
 {
     auto namer = Approvals::getDefaultNamer();
-    REQUIRE_THAT(namer->getApprovedFile(".txt"), !Catch::Matchers::Contains("tag_name" ) );
+    REQUIRE_THAT(namer->getApprovedFile(".txt"),
+                 !Catch::Matchers::Contains("tag_name"));
 }

--- a/tests/Catch2_Tests/reporters/CIBuildOnlyReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/CIBuildOnlyReporterTests.cpp
@@ -8,7 +8,8 @@ TEST_CASE("SampleCIReporter")
 {
     // begin-snippet: report_quietly_on_ci
     // main.cpp
-    auto ciReporterDisposer = CIBuildOnlyReporterUtils::useAsFrontLoadedReporter(
-        std::make_shared<QuietReporter>());
+    auto ciReporterDisposer =
+        CIBuildOnlyReporterUtils::useAsFrontLoadedReporter(
+            std::make_shared<QuietReporter>());
     // end-snippet
 }

--- a/tests/Catch2_Tests/reporters/DoNothingLauncher.h
+++ b/tests/Catch2_Tests/reporters/DoNothingLauncher.h
@@ -11,6 +11,7 @@ class DoNothingLauncher : public ApprovalTests::CommandLauncher
 {
 private:
     std::string cmd;
+
 public:
     bool working = true;
     bool launch(std::vector<std::string> argv) override
@@ -29,4 +30,4 @@ public:
     }
 };
 
-#endif  
+#endif

--- a/tests/Catch2_Tests/reporters/FakeReporter.h
+++ b/tests/Catch2_Tests/reporters/FakeReporter.h
@@ -3,15 +3,18 @@
 
 #include "ApprovalTests/core/Reporter.h"
 
-class FakeReporter : public ApprovalTests::Reporter {
+class FakeReporter : public ApprovalTests::Reporter
+{
 public:
     bool working;
     mutable bool called = false;
 
-    inline FakeReporter(bool working = true) : working(working) {
+    inline FakeReporter(bool working = true) : working(working)
+    {
     }
 
-    inline virtual bool report(std::string /*received*/, std::string /*approved*/) const override
+    inline virtual bool report(std::string /*received*/,
+                               std::string /*approved*/) const override
     {
         called = true;
         return working;

--- a/tests/Catch2_Tests/reporters/ReporterTests.cpp
+++ b/tests/Catch2_Tests/reporters/ReporterTests.cpp
@@ -12,14 +12,16 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("Reporters Launch Command") {
+TEST_CASE("Reporters Launch Command")
+{
     TestReporter m(true);
     bool result = m.report("r.txt", "a.txt");
     REQUIRE(m.launcher.receivedCommand() == "fake r.txt a.txt ");
     REQUIRE(true == result);
 }
 
-TEST_CASE("FirstWorkingReporter") {
+TEST_CASE("FirstWorkingReporter")
+{
     TestReporter* m1 = new TestReporter(false);
     TestReporter* m2 = new TestReporter(true);
     TestReporter* m3 = new TestReporter(true);
@@ -30,29 +32,38 @@ TEST_CASE("FirstWorkingReporter") {
     REQUIRE(true == result);
 }
 
-TEST_CASE("Reporters Report Failure Status") {
+TEST_CASE("Reporters Report Failure Status")
+{
     GenericDiffReporter m("this_does_not_exist");
     bool result = m.report("r.txt", "a.txt");
     REQUIRE(false == result);
 }
 
-TEST_CASE("Reporters Report Success Status") {
-    std::string knownCommand = SystemUtils::isWindowsOs() ? R"(C:\Windows\System32\help.exe)" : "echo";
+TEST_CASE("Reporters Report Success Status")
+{
+    std::string knownCommand =
+        SystemUtils::isWindowsOs() ? R"(C:\Windows\System32\help.exe)" : "echo";
     GenericDiffReporter m(knownCommand);
     bool result = m.report("r.txt", "a.txt");
     REQUIRE(true == result);
 }
 
-TEST_CASE("CommandLauncher can detect missing file") {
-    REQUIRE(false == SystemLauncher().exists("this_file_does_not_exist.txxxxxt"));
+TEST_CASE("CommandLauncher can detect missing file")
+{
+    REQUIRE(false ==
+            SystemLauncher().exists("this_file_does_not_exist.txxxxxt"));
 }
 
-TEST_CASE("ClipboardReporter") {
-    REQUIRE("move /Y \"a.txt\" \"b.txt\"" == ClipboardReporter::getCommandLineFor("a.txt", "b.txt", true));
-    REQUIRE("mv \"a.txt\" \"b.txt\"" == ClipboardReporter::getCommandLineFor("a.txt", "b.txt", false));
+TEST_CASE("ClipboardReporter")
+{
+    REQUIRE("move /Y \"a.txt\" \"b.txt\"" ==
+            ClipboardReporter::getCommandLineFor("a.txt", "b.txt", true));
+    REQUIRE("mv \"a.txt\" \"b.txt\"" ==
+            ClipboardReporter::getCommandLineFor("a.txt", "b.txt", false));
 }
 
-TEST_CASE("CombinationReporter succeeds if any succeed") {
+TEST_CASE("CombinationReporter succeeds if any succeed")
+{
     FakeReporter* m1 = new FakeReporter(true);
     FakeReporter* m2 = new FakeReporter(true);
     CombinationReporter reporter({m1, m2});
@@ -62,7 +73,8 @@ TEST_CASE("CombinationReporter succeeds if any succeed") {
     REQUIRE(result == true);
 }
 
-TEST_CASE("CombinationReporter fails if all fail") {
+TEST_CASE("CombinationReporter fails if all fail")
+{
     FakeReporter* m1 = new FakeReporter(false);
     FakeReporter* m2 = new FakeReporter(false);
     CombinationReporter reporter({m1, m2});
@@ -76,24 +88,24 @@ TEST_CASE("Launching on PC with cygwin and Araxis Merge")
 {
     // Keeping for manual testing when needed
 
-//    REQUIRE_FALSE(SystemUtils::isWindowsOs());
-//    auto reporter = new Windows::AraxisMergeReporter;
-//    auto namer = Approvals::getDefaultNamer();
-//    auto fullCommand = reporter->getFullCommand(
-//        namer->getReceivedFile(".txt"),
-//        namer->getApprovedFile(".txt"));
-//    Approvals::verifyAll(fullCommand, *reporter);
+    //    REQUIRE_FALSE(SystemUtils::isWindowsOs());
+    //    auto reporter = new Windows::AraxisMergeReporter;
+    //    auto namer = Approvals::getDefaultNamer();
+    //    auto fullCommand = reporter->getFullCommand(
+    //        namer->getReceivedFile(".txt"),
+    //        namer->getApprovedFile(".txt"));
+    //    Approvals::verifyAll(fullCommand, *reporter);
 }
-
-
 
 TEST_CASE("Registering default Reporter")
 {
     auto fake_reporter = std::make_shared<FakeReporter>(true);
-    auto default_reporter_disposer = Approvals::useAsDefaultReporter(fake_reporter);
+    auto default_reporter_disposer =
+        Approvals::useAsDefaultReporter(fake_reporter);
     {
         auto fake_reporter2 = std::make_shared<FakeReporter>(true);
-        auto default_reporter_disposer2 = Approvals::useAsDefaultReporter(fake_reporter2);
+        auto default_reporter_disposer2 =
+            Approvals::useAsDefaultReporter(fake_reporter2);
 
         DefaultReporter r;
         r.report("r.txt", "a.txt");
@@ -106,19 +118,19 @@ TEST_CASE("Registering default Reporter")
     REQUIRE(fake_reporter->called == true);
 }
 
-
 TEST_CASE("Front Loaded Reporter Always Takes Precedence")
 {
     auto front_loader = std::make_shared<FakeReporter>(true);
     auto our_reporter = std::make_shared<FakeReporter>(true);
 
-    auto default_reporter_disposer = Approvals::useAsFrontLoadedReporter(front_loader);
+    auto default_reporter_disposer =
+        Approvals::useAsFrontLoadedReporter(front_loader);
 
     try
     {
         Approvals::verify("cucumber", *our_reporter);
     }
-    catch(const std::exception&)
+    catch (const std::exception&)
     {
     }
 
@@ -131,13 +143,14 @@ TEST_CASE("Front Loaded Reporter flows through if not needed")
     auto front_loader = std::make_shared<FakeReporter>(false);
     auto our_reporter = std::make_shared<FakeReporter>(true);
 
-    auto default_reporter_disposer = Approvals::useAsFrontLoadedReporter(front_loader);
+    auto default_reporter_disposer =
+        Approvals::useAsFrontLoadedReporter(front_loader);
 
     try
     {
         Approvals::verify("cucumber", *our_reporter);
     }
-    catch(const std::exception&)
+    catch (const std::exception&)
     {
     }
 
@@ -148,21 +161,25 @@ TEST_CASE("Front Loaded Reporter flows through if not needed")
 TEST_CASE("Unregistering Front Loaded Reporter restores previous")
 {
     auto front_loader1 = std::make_shared<FakeReporter>(true);
-    auto front_loaded_reporter_disposer1 = Approvals::useAsFrontLoadedReporter(front_loader1);
+    auto front_loaded_reporter_disposer1 =
+        Approvals::useAsFrontLoadedReporter(front_loader1);
 
     FakeReporter our_reporter1(true);
 
     {
         auto front_loader2 = std::make_shared<FakeReporter>(true);
-        auto front_loaded_reporter_disposer2 = Approvals::useAsFrontLoadedReporter(front_loader2);
+        auto front_loaded_reporter_disposer2 =
+            Approvals::useAsFrontLoadedReporter(front_loader2);
 
-        FileApprover::reportAfterTryingFrontLoadedReporter("r.txt", "a.txt", our_reporter1);
+        FileApprover::reportAfterTryingFrontLoadedReporter(
+            "r.txt", "a.txt", our_reporter1);
 
         REQUIRE(front_loader2->called == true);
         REQUIRE(front_loader1->called == false);
         REQUIRE(our_reporter1.called == false);
     }
-    FileApprover::reportAfterTryingFrontLoadedReporter("r.txt", "a.txt", our_reporter1);
+    FileApprover::reportAfterTryingFrontLoadedReporter(
+        "r.txt", "a.txt", our_reporter1);
 
     REQUIRE(front_loader1->called == true);
     REQUIRE(our_reporter1.called == false);
@@ -170,10 +187,8 @@ TEST_CASE("Unregistering Front Loaded Reporter restores previous")
 
 namespace
 {
-    template<
-            typename Type,
-            typename = Detail::EnableIfNotDerivedFromReporter<Type, bool>
-            >
+    template <typename Type,
+              typename = Detail::EnableIfNotDerivedFromReporter<Type, bool>>
     bool test_reporter_enabled()
     {
         return true;
@@ -192,9 +207,9 @@ TEST_CASE("EnableIfNotDerivedFromReporter")
     test_reporter_enabled<int>();
     test_reporter_enabled<FileApprover>();
 
-//    test_reporter_enabled<Reporter>();
-//    test_reporter_enabled<Reporter&>();
-//    test_reporter_enabled<const Reporter&>();
+    //    test_reporter_enabled<Reporter>();
+    //    test_reporter_enabled<Reporter&>();
+    //    test_reporter_enabled<const Reporter&>();
     // Must only compile if PossibleReporter's #if is edited:
     test_reporter_enabled<PossibleReporter>();
     test_reporter_enabled<PossibleReporter&>();

--- a/tests/Catch2_Tests/reporters/TestReporter.h
+++ b/tests/Catch2_Tests/reporters/TestReporter.h
@@ -4,11 +4,13 @@
 #include "ApprovalTests/reporters/GenericDiffReporter.h"
 #include "DoNothingLauncher.h"
 
-class TestReporter : public ApprovalTests::CommandReporter {
+class TestReporter : public ApprovalTests::CommandReporter
+{
 public:
     DoNothingLauncher launcher;
 
-    TestReporter(bool working = true) : CommandReporter("fake", &launcher) {
+    TestReporter(bool working = true) : CommandReporter("fake", &launcher)
+    {
         launcher.working = working;
     };
 };

--- a/tests/Catch2_Tests/utilities/CartesianProductTests.cpp
+++ b/tests/Catch2_Tests/utilities/CartesianProductTests.cpp
@@ -17,7 +17,7 @@ using Results = std::vector<std::string>;
 
 namespace
 {
-// A hard-coded struct for accumulating results
+    // A hard-coded struct for accumulating results
     struct AccumulateResults2StringsCommaSeparated
     {
         Results results;
@@ -47,29 +47,31 @@ TEST_CASE("Cartesian product with hard-coded-converter")
 namespace
 {
     // Converter is the lambda, function or similar, that takes a set of input values, and returns a calculated result
-    template<class Converter>
-    struct AccumulateResults
+    template <class Converter> struct AccumulateResults
     {
         Results results;
         Converter converter;
-        template<class T, class... Ts>
-        void operator()(T&& input1, Ts&&... inputs) {
+        template <class T, class... Ts>
+        void operator()(T&& input1, Ts&&... inputs)
+        {
             results.push_back(converter(input1, inputs...));
         }
     };
 
-    template<class Converter, class Container, class... Containers>
-    void test_cartesian_product(const Results& expected, Converter&& converter, const Container& input0,
+    template <class Converter, class Container, class... Containers>
+    void test_cartesian_product(const Results& expected,
+                                Converter&& converter,
+                                const Container& input0,
                                 const Containers&... inputs)
     {
         auto results_store = AccumulateResults<Converter>{
-                Results(),
-                std::forward<Converter>(converter)};
+            Results(), std::forward<Converter>(converter)};
         CartesianProduct::cartesian_product(results_store, input0, inputs...);
         REQUIRE(results_store.results == expected);
     }
 
-    std::string concatenate_2_strings_comma_separated(const std::string& s1, const std::string& s2)
+    std::string concatenate_2_strings_comma_separated(const std::string& s1,
+                                                      const std::string& s2)
     {
         return (s1 + "," + s2);
     }
@@ -82,14 +84,16 @@ TEST_CASE("Cartesian product with iterator types")
     {
         const std::vector<std::string> input1{"A", "B"};
         const std::vector<std::string> input2{"1", "2"};
-        test_cartesian_product(expected, concatenate_2_strings_comma_separated, input1, input2);
+        test_cartesian_product(
+            expected, concatenate_2_strings_comma_separated, input1, input2);
     }
 
     SECTION("bi-directional-access")
     {
         const std::set<std::string> input1{"A", "B"};
         const std::set<std::string> input2{"1", "2"};
-        test_cartesian_product(expected, concatenate_2_strings_comma_separated, input1, input2);
+        test_cartesian_product(
+            expected, concatenate_2_strings_comma_separated, input1, input2);
     }
 }
 
@@ -100,15 +104,19 @@ TEST_CASE("Cartesian product with different types of converter")
     const std::vector<std::string> input2{"1", "2"};
     SECTION("free function")
     {
-        test_cartesian_product(expected, concatenate_2_strings_comma_separated, input1, input2);
+        test_cartesian_product(
+            expected, concatenate_2_strings_comma_separated, input1, input2);
     }
 
     SECTION("lambda expression")
     {
         test_cartesian_product(
-                expected,
-                [](const std::string& s1, const std::string& s2){return s1 + "," + s2;},
-                input1, input2);
+            expected,
+            [](const std::string& s1, const std::string& s2) {
+                return s1 + "," + s2;
+            },
+            input1,
+            input2);
     }
 }
 
@@ -117,7 +125,8 @@ TEST_CASE("Cartesian product works with mixed input types")
     const std::vector<std::string> input1{"hello"};
     const std::set<std::string> input2{"world"};
     const Results expected{"hello,world"};
-    test_cartesian_product(expected, concatenate_2_strings_comma_separated, input1, input2);
+    test_cartesian_product(
+        expected, concatenate_2_strings_comma_separated, input1, input2);
 }
 
 TEST_CASE("Cartesian product with an empty input gives empty output")
@@ -125,5 +134,6 @@ TEST_CASE("Cartesian product with an empty input gives empty output")
     const std::set<std::string> input1{"A", "B"};
     const std::set<std::string> input2;
     const Results expected;
-    test_cartesian_product(expected, concatenate_2_strings_comma_separated, input1, input2);
+    test_cartesian_product(
+        expected, concatenate_2_strings_comma_separated, input1, input2);
 }

--- a/tests/Catch2_Tests/utilities/FileUtilsSystemSpecificTests.cpp
+++ b/tests/Catch2_Tests/utilities/FileUtilsSystemSpecificTests.cpp
@@ -9,16 +9,17 @@ using namespace ApprovalTests;
 
 TEST_CASE("ItCanCopyAFile")
 {
-  ApprovalTestNamer namer;
-  const auto& sep = SystemUtils::getDirectorySeparator();
-  auto source = namer.getDirectory() + ".." + sep + ".." + sep + "sample.txt";
-    auto destination = namer.getDirectory() + ".." + sep + "copy.temp.received.txt";
+    ApprovalTestNamer namer;
+    const auto& sep = SystemUtils::getDirectorySeparator();
+    auto source = namer.getDirectory() + ".." + sep + ".." + sep + "sample.txt";
+    auto destination =
+        namer.getDirectory() + ".." + sep + "copy.temp.received.txt";
 
-    if ( FileUtils::fileExists(destination))
+    if (FileUtils::fileExists(destination))
     {
         ::remove(destination.c_str());
     }
-    CHECK( ! FileUtils::fileExists(destination) );
+    CHECK(!FileUtils::fileExists(destination));
     FileUtilsSystemSpecific::copyFile(source, destination);
     Approvals::verifyExistingFile(destination);
 }

--- a/tests/Catch2_Tests/utilities/MachineBlockerTests.cpp
+++ b/tests/Catch2_Tests/utilities/MachineBlockerTests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Does not block in this environment")
 TEST_CASE("Only run this test on John's machine")
 {
     auto blocker = MachineBlocker::onMachinesNotNamed("JOHNS_MACHINE");
-    if ( blocker.isBlockingOnThisMachine() )
+    if (blocker.isBlockingOnThisMachine())
     {
         return;
     }

--- a/tests/Catch2_Tests/utilities/StringUtilsTests.cpp
+++ b/tests/Catch2_Tests/utilities/StringUtilsTests.cpp
@@ -3,6 +3,7 @@
 
 using namespace ApprovalTests;
 
-TEST_CASE("TestLowerCase") {
+TEST_CASE("TestLowerCase")
+{
     REQUIRE(StringUtils::toLower("MiXeD CaSe") == "mixed case");
 }

--- a/tests/Catch2_Tests/utilities/SystemUtilsTests.cpp
+++ b/tests/Catch2_Tests/utilities/SystemUtilsTests.cpp
@@ -7,11 +7,13 @@ using namespace ApprovalTests;
 
 TEST_CASE("ItCanFixCaseOfFileNameOnWindows")
 {
-    if( SystemUtils::isWindowsOs())
+    if (SystemUtils::isWindowsOs())
     {
         const std::string original_filename = __FILE__;
-        const std::string lowercased_filename = StringUtils::toLower(original_filename);
-        const std::string fixed_filename = SystemUtils::checkFilenameCase(lowercased_filename);
+        const std::string lowercased_filename =
+            StringUtils::toLower(original_filename);
+        const std::string fixed_filename =
+            SystemUtils::checkFilenameCase(lowercased_filename);
         INFO("The 'fixed' filename is " << fixed_filename);
 
         REQUIRE(original_filename.length() == fixed_filename.length());
@@ -31,7 +33,8 @@ TEST_CASE("ItCanGetEnvironmentVariable")
 
 TEST_CASE("ItCanGetNonExistentEnvironmentVariable")
 {
-    const auto result = SystemUtils::safeGetEnv("THIS_ENVIRONMENT_VARIABLE_SHOULD_NOT_EXIST");
+    const auto result =
+        SystemUtils::safeGetEnv("THIS_ENVIRONMENT_VARIABLE_SHOULD_NOT_EXIST");
     REQUIRE(result.length() == 0);
 }
 
@@ -41,5 +44,5 @@ TEST_CASE("ItCanCreateSubDirectory")
     ApprovalTestNamer namer;
     auto directory = namer.getDirectory();
     REQUIRE(FileUtils::fileExists(directory) == true);
-//    SystemUtils::removeDirectory(directory);
+    //    SystemUtils::removeDirectory(directory);
 }

--- a/tests/Catch2_Tests/writers/StringWriterTests.cpp
+++ b/tests/Catch2_Tests/writers/StringWriterTests.cpp
@@ -4,7 +4,8 @@
 
 using namespace ApprovalTests;
 
-std::string readFileAndDelete(const char *fileName) {
+std::string readFileAndDelete(const char* fileName)
+{
     std::ifstream in(fileName, std::ios_base::in);
     std::stringstream written;
     written << in.rdbuf();
@@ -15,7 +16,8 @@ std::string readFileAndDelete(const char *fileName) {
     return text;
 }
 
-TEST_CASE("ItWritesTheContentsToAFile") {
+TEST_CASE("ItWritesTheContentsToAFile")
+{
     StringWriter s("Hello");
     auto fileName = "out.txt";
     s.write(fileName);
@@ -24,25 +26,29 @@ TEST_CASE("ItWritesTheContentsToAFile") {
     REQUIRE(text == "Hello\n");
 }
 
-TEST_CASE("ItWritesTheContentsToAStream") {
+TEST_CASE("ItWritesTheContentsToAStream")
+{
     std::stringstream out;
     StringWriter s("Hello");
     s.Write(out);
     REQUIRE(out.str() == "Hello\n");
 }
 
-TEST_CASE("TheDefaultExtensionIsText") {
+TEST_CASE("TheDefaultExtensionIsText")
+{
     StringWriter s("Hello");
     REQUIRE(s.getFileExtensionWithDot() == ".txt");
 }
 
-TEST_CASE("TheExtensionIsConfigurable") {
+TEST_CASE("TheExtensionIsConfigurable")
+{
     StringWriter s("Hello", ".html");
     REQUIRE(s.getFileExtensionWithDot() == ".html");
 }
 
-TEST_CASE("ItGivesMeaningfulErrorIfWritingFails") {
+TEST_CASE("ItGivesMeaningfulErrorIfWritingFails")
+{
     StringWriter s("Hello");
     auto fileName = "I/do/not/exist/out.txt";
-    Approvals::verifyExceptionMessage([&](){s.write(fileName);});
+    Approvals::verifyExceptionMessage([&]() { s.write(fileName); });
 }

--- a/tests/DocTest_Tests/ApprovalTestTests.cpp
+++ b/tests/DocTest_Tests/ApprovalTestTests.cpp
@@ -27,5 +27,8 @@ TEST_CASE("YouCanSpecifyYourFileExtensionWithToString")
 
 TEST_CASE("YouCanSpecifyYourFileExtensionWithFormatter")
 {
-    Approvals::verifyWithExtension(1337, [](auto value, auto& os){os << "**value:** " << value;}, ".md");
+    Approvals::verifyWithExtension(
+        1337,
+        [](auto value, auto& os) { os << "**value:** " << value; },
+        ".md");
 }

--- a/tests/DocTest_Tests/documentation/DisposableSamples.cpp
+++ b/tests/DocTest_Tests/documentation/DisposableSamples.cpp
@@ -9,7 +9,7 @@ TEST_CASE("DisposableSample")
     // end-snippet
 
     auto disposer2 =
-    // begin-snippet: disposable_incorrect
-    Approvals::useApprovalsSubdirectory("directory");
+        // begin-snippet: disposable_incorrect
+        Approvals::useApprovalsSubdirectory("directory");
     // end-snippet
 }

--- a/tests/DocTest_Tests/documentation/DocTestDocumentationSamples.cpp
+++ b/tests/DocTest_Tests/documentation/DocTestDocumentationSamples.cpp
@@ -24,7 +24,7 @@ struct Greeting
     explicit Greeting(Nationality nationality) : nationality(nationality)
     {
     }
-    
+
     std::string getGreeting() const
     {
         return getGreetingFor(nationality);
@@ -32,31 +32,31 @@ struct Greeting
 
     std::string getGreetingFor(Nationality aNationality) const
     {
-        switch(aNationality)
+        switch (aNationality)
         {
-            case British:
-                return "Cheers";
-            case American:
-                return "Howdy";
-            case French:
-                return "Bonjour";
-            default:
-                return "Unknown";
+        case British:
+            return "Cheers";
+        case American:
+            return "Howdy";
+        case French:
+            return "Bonjour";
+        default:
+            return "Unknown";
         }
     }
 
     std::string getNationality() const
     {
-        switch(nationality)
+        switch (nationality)
         {
-            case British:
-                return "British";
-            case American:
-                return "American";
-            case French:
-                return "French";
-            default:
-                return "Unknown";
+        case British:
+            return "British";
+        case American:
+            return "American";
+        case French:
+            return "French";
+        default:
+            return "Unknown";
         }
     }
 };
@@ -87,10 +87,12 @@ TEST_CASE("ApprovalTests-MultipleOutputFiles-DataDriven")
     // Note: For data as small as this, in practice we would recommend passing the
     // greetings container in to Approvals::verifyAll(), with a lambda to format the output,
     // in order to write all data to a single file.
-    std::vector<Greeting> greetings{ Greeting(British), Greeting(American), Greeting(French) };
-    for(auto greeting: greetings)
+    std::vector<Greeting> greetings{
+        Greeting(British), Greeting(American), Greeting(French)};
+    for (auto greeting : greetings)
     {
-        auto section = NamerFactory::appendToOutputFilename(greeting.getNationality());
+        auto section =
+            NamerFactory::appendToOutputFilename(greeting.getNationality());
         Approvals::verify(greeting.getGreeting());
     }
 }
@@ -120,12 +122,15 @@ TEST_CASE("ApprovalTests-MultipleOutputFiles-AutoApproving")
 {
     using namespace ApprovalTests;
 
-    ExceptionCollector exceptions; // Allow all files to be written, regardless of errors
-    std::vector<Greeting> greetings{Greeting(British), Greeting(American), Greeting(French)};
-    for (auto greeting: greetings)
+    ExceptionCollector
+        exceptions; // Allow all files to be written, regardless of errors
+    std::vector<Greeting> greetings{
+        Greeting(British), Greeting(American), Greeting(French)};
+    for (auto greeting : greetings)
     {
-        auto section = NamerFactory::appendToOutputFilename(greeting.getNationality());
-        exceptions.gather([&](){
+        auto section =
+            NamerFactory::appendToOutputFilename(greeting.getNationality());
+        exceptions.gather([&]() {
             Approvals::verify(
                 greeting.getGreeting(),
                 AutoApproveIfMissingReporter()); // Automatically approve first time
@@ -134,4 +139,3 @@ TEST_CASE("ApprovalTests-MultipleOutputFiles-AutoApproving")
     exceptions.release();
 }
 // end-snippet
-

--- a/tests/DocTest_Tests/documentation/ForgottenToConfigure.cpp
+++ b/tests/DocTest_Tests/documentation/ForgottenToConfigure.cpp
@@ -4,10 +4,11 @@
 using namespace ApprovalTests;
 TEST_CASE("HelpMessage")
 {
-    Approvals::verify( ApprovalTestNamer::getMisconfiguredMainHelp() );
+    Approvals::verify(ApprovalTestNamer::getMisconfiguredMainHelp());
 }
 
 TEST_CASE("HelpMessageForIncorrectBuildConfig")
 {
-    Approvals::verify( TestName::getMisconfiguredBuildHelp("../../../tests/Catch1_Tests/ApprovalsTests.cpp") );
+    Approvals::verify(TestName::getMisconfiguredBuildHelp(
+        "../../../tests/Catch1_Tests/ApprovalsTests.cpp"));
 }

--- a/tests/DocTest_Tests/namers/DocTestNamerTests.cpp
+++ b/tests/DocTest_Tests/namers/DocTestNamerTests.cpp
@@ -11,10 +11,13 @@ TEST_CASE("ItCanGiveYouTheSpecName")
 
     SUBCASE("andSectionNames")
     {
-        REQUIRE(namer.getTestName() == "ItCanGiveYouTheSpecName.andSectionNames");
+        REQUIRE(namer.getTestName() ==
+                "ItCanGiveYouTheSpecName.andSectionNames");
         SUBCASE("andEvenMoreSectionNames")
         {
-            REQUIRE(namer.getTestName() == "ItCanGiveYouTheSpecName.andSectionNames.andEvenMoreSectionNames");
+            REQUIRE(namer.getTestName() ==
+                    "ItCanGiveYouTheSpecName.andSectionNames."
+                    "andEvenMoreSectionNames");
         }
     }
 }

--- a/tests/DocTest_Tests/namers/NamerTests.cpp
+++ b/tests/DocTest_Tests/namers/NamerTests.cpp
@@ -10,11 +10,13 @@ using namespace ApprovalTests;
 
 class FakeNamer : public ApprovalNamer
 {
-    virtual std::string getApprovedFile(std::string /*extensionWithDot*/) const override
+    virtual std::string
+        getApprovedFile(std::string /*extensionWithDot*/) const override
     {
         return "my.approved";
     }
-    virtual std::string getReceivedFile(std::string /*extensionWithDot*/) const override 
+    virtual std::string
+        getReceivedFile(std::string /*extensionWithDot*/) const override
     {
         return "my.received";
     }
@@ -24,13 +26,15 @@ TEST_CASE("Registering default Namer")
 {
     {
         // begin-snippet: register_default_namer
-        auto default_namer_disposer = Approvals::useAsDefaultNamer([](){return std::make_shared<FakeNamer>();});
+        auto default_namer_disposer = Approvals::useAsDefaultNamer(
+            []() { return std::make_shared<FakeNamer>(); });
         // end-snippet
         auto result = Approvals::getDefaultNamer()->getApprovedFile(".txt");
         REQUIRE(result == "my.approved");
     }
     auto result = Approvals::getDefaultNamer()->getApprovedFile(".txt");
-    REQUIRE(StringUtils::endsWith(result, "NamerTests.Registering_default_Namer.approved.txt"));
+    REQUIRE(StringUtils::endsWith(
+        result, "NamerTests.Registering_default_Namer.approved.txt"));
 }
 
 void require_ends_with(const std::string& text, const std::string& endsWith)
@@ -42,27 +46,35 @@ void require_ends_with(const std::string& text, const std::string& endsWith)
 TEST_CASE("SeparateApprovedAndReceivedDirectoriesNamer")
 {
     // begin-snippet: register_separate_directories_namer
-    auto default_namer_disposer = SeparateApprovedAndReceivedDirectoriesNamer::useAsDefaultNamer();
+    auto default_namer_disposer =
+        SeparateApprovedAndReceivedDirectoriesNamer::useAsDefaultNamer();
     // end-snippet
 
     auto namer = Approvals::getDefaultNamer();
-    require_ends_with(namer->getApprovedFile(".txt"), "approved" + SystemUtils::getDirectorySeparator() +
-                                                      "NamerTests.SeparateApprovedAndReceivedDirectoriesNamer.txt");
-    require_ends_with(namer->getReceivedFile(".txt"), "received" + SystemUtils::getDirectorySeparator() +
-                                                      "NamerTests.SeparateApprovedAndReceivedDirectoriesNamer.txt");
+    require_ends_with(
+        namer->getApprovedFile(".txt"),
+        "approved" + SystemUtils::getDirectorySeparator() +
+            "NamerTests.SeparateApprovedAndReceivedDirectoriesNamer.txt");
+    require_ends_with(
+        namer->getReceivedFile(".txt"),
+        "received" + SystemUtils::getDirectorySeparator() +
+            "NamerTests.SeparateApprovedAndReceivedDirectoriesNamer.txt");
 }
 
-TEST_CASE( "AdditionalSections" )
+TEST_CASE("AdditionalSections")
 {
     auto namer = Approvals::getDefaultNamer();
 
     {
         auto section_namer = NamerFactory::appendToOutputFilename("case1");
-        require_ends_with(namer->getApprovedFile(".txt"), "NamerTests.AdditionalSections.case1.approved.txt");
+        require_ends_with(namer->getApprovedFile(".txt"),
+                          "NamerTests.AdditionalSections.case1.approved.txt");
     }
     {
         auto section_namer = NamerFactory::appendToOutputFilename("case2");
-        require_ends_with(namer->getApprovedFile(".txt"), "NamerTests.AdditionalSections.case2.approved.txt");
+        require_ends_with(namer->getApprovedFile(".txt"),
+                          "NamerTests.AdditionalSections.case2.approved.txt");
     }
-    require_ends_with(namer->getApprovedFile(".txt"), "NamerTests.AdditionalSections.approved.txt");
+    require_ends_with(namer->getApprovedFile(".txt"),
+                      "NamerTests.AdditionalSections.approved.txt");
 }

--- a/tests/DocTest_Tests/utilities/ExceptionCollectorTests.cpp
+++ b/tests/DocTest_Tests/utilities/ExceptionCollectorTests.cpp
@@ -8,23 +8,26 @@ using namespace ApprovalTests;
 TEST_CASE("ExceptionCollector")
 {
     using namespace ApprovalTests;
-    Approvals::verifyExceptionMessage([]()
-      {
-          ExceptionCollector exceptions;
-          for (int i = 1; i <= 4; ++i) {
-              exceptions.gather(
-                      [&]() { throw std::runtime_error("error number " + StringUtils::toString(i)); });
-          }
-          exceptions.release();
-      });
+    Approvals::verifyExceptionMessage([]() {
+        ExceptionCollector exceptions;
+        for (int i = 1; i <= 4; ++i)
+        {
+            exceptions.gather([&]() {
+                throw std::runtime_error("error number " +
+                                         StringUtils::toString(i));
+            });
+        }
+        exceptions.release();
+    });
 }
 
 TEST_CASE("ExceptionCollectorSampleTemplate")
 {
     // begin-snippet: exception_collector_template
     ExceptionCollector exceptions;
-    for (int i = 1; i <= 4; ++i) {
-        exceptions.gather([&](){/* Code that may throw errors here */});
+    for (int i = 1; i <= 4; ++i)
+    {
+        exceptions.gather([&]() { /* Code that may throw errors here */ });
     }
     exceptions.release(); // All errors actually thrown together here
     // end-snippet

--- a/tests/GoogleTest_Tests/namers/GoogleFixtureNamerCustomizationTests.cpp
+++ b/tests/GoogleTest_Tests/namers/GoogleFixtureNamerCustomizationTests.cpp
@@ -7,7 +7,8 @@ using namespace ApprovalTests;
 
 // begin-snippet: googletest_customize_suffix
 // main.cpp
-auto customization = GoogleConfiguration::addIgnorableTestCaseNameSuffix("Fixture");
+auto customization =
+    GoogleConfiguration::addIgnorableTestCaseNameSuffix("Fixture");
 // end-snippet
 
 // begin-snippet: googletest_name_parts
@@ -15,44 +16,53 @@ TEST(TestCaseName, TestName)
 // end-snippet
 {
     ApprovalTestNamer namer;
-    EXPECT_EQ(namer.getOutputFileBaseName(), "GoogleFixtureNamerCustomizationTests.TestCaseName.TestName");
+    EXPECT_EQ(namer.getOutputFileBaseName(),
+              "GoogleFixtureNamerCustomizationTests.TestCaseName.TestName");
 }
 
 TEST(GoogleFixtureNamerCustomizationTests, EliminatesDuplicatedClassName)
 {
     ApprovalTestNamer namer;
-    EXPECT_EQ(namer.getOutputFileBaseName(), "GoogleFixtureNamerCustomizationTests.EliminatesDuplicatedClassName");
+    EXPECT_EQ(
+        namer.getOutputFileBaseName(),
+        "GoogleFixtureNamerCustomizationTests.EliminatesDuplicatedClassName");
 }
 
-class GoogleFixtureNamerCustomizationTestsFixture : public ::testing::Test{};
+class GoogleFixtureNamerCustomizationTestsFixture : public ::testing::Test
+{
+};
 
 TEST_F(GoogleFixtureNamerCustomizationTestsFixture, OnlyMatchesFixtureAtEnd)
 {
     ApprovalTestNamer namer;
-    EXPECT_EQ(namer.getOutputFileBaseName(), "GoogleFixtureNamerCustomizationTests.OnlyMatchesFixtureAtEnd");
+    EXPECT_EQ(namer.getOutputFileBaseName(),
+              "GoogleFixtureNamerCustomizationTests.OnlyMatchesFixtureAtEnd");
 }
 
 // begin-snippet: googletest_customize_function
 // main.cpp
-bool dropTestCaseNamesWithIgnoreThis(const std::string& /*testFileNameWithExtension*/, const std::string& testCaseName)
+bool dropTestCaseNamesWithIgnoreThis(
+    const std::string& /*testFileNameWithExtension*/,
+    const std::string& testCaseName)
 {
     return StringUtils::contains(testCaseName, "IgnoreThis");
 }
 
-auto ignoreNames = GoogleConfiguration::addTestCaseNameRedundancyCheck(dropTestCaseNamesWithIgnoreThis);
+auto ignoreNames = GoogleConfiguration::addTestCaseNameRedundancyCheck(
+    dropTestCaseNamesWithIgnoreThis);
 // end-snippet
 
 // begin-snippet: googletest_customize_lambda
 // main.cpp
 auto ignoreNamesLambda = GoogleConfiguration::addTestCaseNameRedundancyCheck(
-    [](const std::string& /*testFileNameWithExtension*/, const std::string& testCaseName)
-    {
+    [](const std::string& /*testFileNameWithExtension*/,
+       const std::string& testCaseName) {
         return StringUtils::contains(testCaseName, "IgnoreThis");
     });
 // end-snippet
 
 // begin-snippet: googletest_customize_test
-TEST(TestCaseName_IgnoreThis, TestName )
+TEST(TestCaseName_IgnoreThis, TestName)
 // end-snippet
 {
     ApprovalTestNamer namer;
@@ -63,4 +73,3 @@ TEST(TestCaseName_IgnoreThis, TestName )
 
     EXPECT_EQ(namer.getOutputFileBaseName(), outputFileBaseName);
 }
-

--- a/tests/GoogleTest_Tests/namers/GoogleNamerTest.cpp
+++ b/tests/GoogleTest_Tests/namers/GoogleNamerTest.cpp
@@ -17,12 +17,16 @@ TEST(GoogleNamerTest, ItDropsFirstNameWhenItEqualsTheFilename)
 TEST(TestCaseNameDifferentNameThanFile, TestName)
 {
     ApprovalTestNamer namer;
-    EXPECT_EQ(namer.getTestName(), "TestCaseNameDifferentNameThanFile.TestName");
+    EXPECT_EQ(namer.getTestName(),
+              "TestCaseNameDifferentNameThanFile.TestName");
 }
 
-std::string createSuffix(const std::string& suffix, const std::string& fileName, const std::string& testCaseName)
+std::string createSuffix(const std::string& suffix,
+                         const std::string& fileName,
+                         const std::string& testCaseName)
 {
-    auto converter = GoogleConfiguration::createIgnorableTestCaseNameSuffixCheck(suffix);
+    auto converter =
+        GoogleConfiguration::createIgnorableTestCaseNameSuffixCheck(suffix);
     return converter(fileName, testCaseName) ? "redundant" : "";
 }
 
@@ -30,13 +34,20 @@ TEST(GoogleNamerTest, TestSuffixMatcher)
 {
     std::string suffix = "Test";
     std::string fileName = "/a/b/c/testGoogleNamer.cpp";
-    std::vector<std::string> testCaseNames = {"GoogleNamerTest", "GoogleNamer", "GoogleTest", "NamerTest", "NamerTestTest", "NamerTestTests", "TestTest", "Test"};
+    std::vector<std::string> testCaseNames = {"GoogleNamerTest",
+                                              "GoogleNamer",
+                                              "GoogleTest",
+                                              "NamerTest",
+                                              "NamerTestTest",
+                                              "NamerTestTests",
+                                              "TestTest",
+                                              "Test"};
     Approvals::verifyAll<std::vector<std::string>>(
-        "suffix: " + suffix + 
-        "\nfilename: " + fileName + 
-        "\ntest case names:",
+        "suffix: " + suffix + "\nfilename: " + fileName + "\ntest case names:",
         testCaseNames,
-        [&](const std::string& test, std::ostream& os){os << test << ": " << createSuffix(suffix, fileName, test);});
+        [&](const std::string& test, std::ostream& os) {
+            os << test << ": " << createSuffix(suffix, fileName, test);
+        });
 }
 
 TEST(GoogleNamerTest, TestSuffixMatcherBug)
@@ -44,7 +55,7 @@ TEST(GoogleNamerTest, TestSuffixMatcherBug)
     std::string testCaseName = "ApprovalTestsTest";
     std::string suffix = "Test";
     std::string fileName = "/a/b/c/testApprovalTests.cpp";
-    auto converter = GoogleConfiguration::createIgnorableTestCaseNameSuffixCheck(suffix);
+    auto converter =
+        GoogleConfiguration::createIgnorableTestCaseNameSuffixCheck(suffix);
     EXPECT_EQ(converter(fileName, testCaseName), true);
 }
-

--- a/tests/UT_Tests/ApprovalTestTests.cpp
+++ b/tests/UT_Tests/ApprovalTestTests.cpp
@@ -12,12 +12,14 @@ int main()
 
     // begin-snippet: ut_main_usage
     "ItCanVerifyAFile"_test = []() {
-        Approvals::verify("Approval Tests can verify text via the golden master method");
-	};
+        Approvals::verify(
+            "Approval Tests can verify text via the golden master method");
+    };
     // end-snippet
 
     test("AnotherWayItCanVerifyAFile") = []() {
-        Approvals::verify("Approval Tests can verify text via the golden master method");
+        Approvals::verify(
+            "Approval Tests can verify text via the golden master method");
     };
 
     // begin-snippet: ut_main_multiple
@@ -26,11 +28,13 @@ int main()
             // Here we simulate test sections, so that Approval Tests uses different
             // output file names for the different verify() calls.
             auto section = NamerFactory::appendToOutputFilename("section 1");
-            Approvals::verify("Approval Tests can verify text via the golden master method");
+            Approvals::verify(
+                "Approval Tests can verify text via the golden master method");
         }
         {
             auto section = NamerFactory::appendToOutputFilename("section 2");
-            Approvals::verify("Approval Tests can verify different text via the golden master method");
+            Approvals::verify("Approval Tests can verify different text via "
+                              "the golden master method");
         }
     };
     // end-snippet
@@ -54,6 +58,9 @@ int main()
     };
 
     "YouCanSpecifyYourFileExtensionWithFormatter"_test = []() {
-        Approvals::verifyWithExtension(1337, [](auto value, auto& os) {os << "**value:** " << value; }, ".md");
+        Approvals::verifyWithExtension(
+            1337,
+            [](auto value, auto& os) { os << "**value:** " << value; },
+            ".md");
     };
 }

--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
Add .clang-format and applies.

Unfortunately this creates a very large changeset.

A large portion of the changes are indention due to indenting the namespace. Proceeding with indenting the namespace was chosen to be consistent with the style guide namespace file. https://github.com/approvals/ApprovalTests.cpp/blob/master/tests/Catch2_Tests/StyleGuide.h. Same is true of brace style.

Initializer list break `BeforeComma` was chosen because the original had the `:` on a separate line which helps make it clear where the parameter list ends and the initializer list starts. Unfortunately, `clang-format` does not have that particular style as an option so the break `BeforeComma` was chosen to preserve the intent of helping distinguish between parameters on separate lines and initializer list elements.

A `.clang-format` file was added to the `third_party` directory to try to prevent reformatting that directory per this SO answer: https://stackoverflow.com/a/56243326/973447.  That did not work when I ran the reformat on the command line (`find . -name "*.h" -o -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i`), but it might work for IDEs??


Closes #39 


