### PR TITLE
c Remove Catch1 for README as a supported test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ They are great for testing objects with lots of fields, or lists of objects.
 
 * C++11 (or above) compiler
 * Mac/Linux/Windows
-* One of:  [GoogleTest](https://github.com/google/googletest), [Catch1](https://github.com/catchorg/Catch2/tree/Catch1.x), [Catch2](https://github.com/catchorg/Catch2), [doctest](https://github.com/onqtam/doctest), [\[Boost\].UT](https://github.com/boost-experimental/ut)
+* One of:  [GoogleTest](https://github.com/google/googletest), [Catch2](https://github.com/catchorg/Catch2), [doctest](https://github.com/onqtam/doctest), [\[Boost\].UT](https://github.com/boost-experimental/ut)
 
 ## Getting Started
 

--- a/doc/mdsource/UsingCatch.source.md
+++ b/doc/mdsource/UsingCatch.source.md
@@ -7,15 +7,13 @@ toc
 
 
 
-## Getting Started With Catch 1 and 2
+## Getting Started With Catch 2
 
 The [Catch2](https://github.com/catchorg/Catch2) test framework works well with Approval Tests.
 
 This section describes the various ways of using Approval Tests with Catch 2.
 
-These steps also work with the earlier version, Catch 1, which is on the [Catch 1.x branch](https://github.com/catchorg/Catch2/tree/Catch1.x), and is still provided for those on pre-C++11 compilers. (Please note that the Approval Tests library requires C++11 or newer, however). 
-
-Approval Tests requires that a file called `catch.hpp` is found.
+Approval Tests requires that a file called `catch2/catch.hpp` is found.
 
 (Before v7.0.0, it required `Catch.hpp`)
 
@@ -36,11 +34,11 @@ snippet: catch_2_main
 
 ### Existing Project - with CATCH_CONFIG_MAIN
 
-If you have a Catch (1 or 2) project with your own `main.cpp` that contains the following lines, you will need to replace them with the code in the previous section.
+If you have a Catch 2 project with your own `main.cpp` that contains the following lines, you will need to replace them with the code in the previous section.
 
 ```cpp
 #define CATCH_CONFIG_MAIN // remove these lines, and replace with Approval Tests lines
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 ```
 
 <!-- todo: document use of sections -->

--- a/mdsource/README.source.md
+++ b/mdsource/README.source.md
@@ -18,7 +18,7 @@ They are great for testing objects with lots of fields, or lists of objects.
 
 * C++11 (or above) compiler
 * Mac/Linux/Windows
-* One of:  [GoogleTest](https://github.com/google/googletest), [Catch1](https://github.com/catchorg/Catch2/tree/Catch1.x), [Catch2](https://github.com/catchorg/Catch2), [doctest](https://github.com/onqtam/doctest), [\[Boost\].UT](https://github.com/boost-experimental/ut)
+* One of:  [GoogleTest](https://github.com/google/googletest), [Catch2](https://github.com/catchorg/Catch2), [doctest](https://github.com/onqtam/doctest), [\[Boost\].UT](https://github.com/boost-experimental/ut)
 
 ## Getting Started
 


### PR DESCRIPTION
c Remove Catch1 from README as a supported test harness. Catch1 support was removed during resolution of issue #62 