### PR TITLE
Add clang-format job to GitHub Actions build

### DIFF
--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -3,6 +3,15 @@ name: build
 on: [push, pull_request]
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: DoozyX/clang-format-lint-action@v0.5
+        with:
+          source: '.'
+          exclude: './third_party'
+          clangFormatVersion: 9
   build:
     strategy:
       matrix:


### PR DESCRIPTION
This should run a clang-format job to check code is formatted correctly - the GitHub actions build will fail if it is not.