### PR TITLE
Move only disposer

### DIFF
--- a/ApprovalTests/comparators/ComparatorDisposer.h
+++ b/ApprovalTests/comparators/ComparatorDisposer.h
@@ -28,12 +28,28 @@ namespace ApprovalTests
             comparators[extensionWithDot] = newComparator;
         }
 
+        ComparatorDisposer(const ComparatorDisposer&) = delete;
+
+        ComparatorDisposer(ComparatorDisposer&& other)
+            : comparators(other.comparators)
+            , ext_(std::move(other.ext_))
+            , previousComparator(std::move(other.previousComparator))
+        {
+            other.isActive = false;
+        }
+
         ~ComparatorDisposer()
         {
-            comparators[ext_] = previousComparator;
+            if (isActive)
+            {
+                comparators[ext_] = previousComparator;
+            }
         }
 
     private:
+        // A disposer becomes inactive when it is moved from.
+        // This is done to prevent a comparator from being disposed twice.
+        bool isActive = true;
         ComparatorContainer& comparators;
         std::string ext_;
         std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator;

--- a/tests/Catch2_Tests/CMakeLists.txt
+++ b/tests/Catch2_Tests/CMakeLists.txt
@@ -2,6 +2,7 @@ project(Catch2_Tests)
 set(CMAKE_CXX_STANDARD 17)
 add_executable(${PROJECT_NAME}
     main.cpp
+    comparators/ComparatorDisposerTest.cpp
     core/ApprovalExceptionTests.cpp
     ApprovalsTests.cpp
     CombinationTests.cpp

--- a/tests/Catch2_Tests/comparators/ComparatorDisposerTest.cpp
+++ b/tests/Catch2_Tests/comparators/ComparatorDisposerTest.cpp
@@ -1,0 +1,75 @@
+#include "catch2/catch.hpp"
+#include "ApprovalTests/comparators/ComparatorDisposer.h"
+#include "Approvals.h"
+#include <fstream>
+#include <iterator>
+#include <memory>
+
+using namespace ApprovalTests;
+
+namespace
+{
+    class CaseInsensitiveComparator : public ApprovalComparator
+    {
+    public:
+        bool contentsAreEquivalent(std::string receivedPath,
+                                   std::string approvedPath) const override
+        {
+            std::ifstream receivedStream(receivedPath.c_str());
+            std::ifstream approvedStream(approvedPath.c_str());
+
+            using InputIter = std::istreambuf_iterator<char>;
+
+            auto receivedText =
+                std::string(InputIter{receivedStream}, InputIter{});
+            auto approvedText =
+                std::string(InputIter{approvedStream}, InputIter{});
+
+            return StringUtils::toLower(receivedText) ==
+                   StringUtils::toLower(approvedText);
+        }
+    };
+}
+
+TEST_CASE("Type traits of ComparatorDisposer")
+{
+
+    REQUIRE_FALSE(std::is_copy_constructible<ComparatorDisposer>::value);
+    REQUIRE_FALSE(std::is_copy_assignable<ComparatorDisposer>::value);
+
+    REQUIRE(std::is_move_constructible<ComparatorDisposer>::value);
+    REQUIRE_FALSE(std::is_move_assignable<ComparatorDisposer>::value);
+}
+
+TEST_CASE("ComparatorDisposer object can be moved without disposing a "
+          "comparator twice")
+{
+    FileUtils::writeToFile("a.txt", "foo");
+    FileUtils::writeToFile("b.txt", "FOO");
+
+    // Case-insensitive comparator is not registered - files are not equivalent
+    REQUIRE_THROWS_AS(FileApprover::verify("a.txt", "b.txt"),
+                      ApprovalMismatchException);
+
+    std::unique_ptr<ComparatorDisposer> disposer;
+
+    {
+        auto temporaryDisposer = FileApprover::registerComparatorForExtension(
+            ".txt", std::make_shared<CaseInsensitiveComparator>());
+
+        // The comparator is registered - files are equivalent
+        REQUIRE_NOTHROW(FileApprover::verify("a.txt", "b.txt"));
+
+        disposer.reset(new ComparatorDisposer(std::move(temporaryDisposer)));
+    }
+
+    // The comparator is still registered - files are equivalent
+    REQUIRE_NOTHROW(FileApprover::verify("a.txt", "b.txt"));
+
+    // Deregisters the comparator
+    disposer.reset();
+
+    // The comparator is no longer registered - files are not equivalent
+    REQUIRE_THROWS_AS(FileApprover::verify("a.txt", "b.txt"),
+                      ApprovalMismatchException);
+}


### PR DESCRIPTION
## Description

I came across this problem when writing an utility method, which registers the same comparator for multiple file extensions: [link](https://github.com/p-podsiadly/ImageApprovals/blob/43a363ae6f99994a76385a645820291e6afb1e65/ImageApprovals/src/Comparator.cpp#L41).

In linked code, `Disposer` class wraps a vector of `ComparatorDisposer` objects. Each `ComparatorDisposer` is created by `FileApprover::registerComparatorForExtension`, copied to a vector and destructed and at that point the comparator is immediately disposed.

Expected behavior is that the comparator is disposed once the copy in the vector is destructed. Destructor of the original `ComparatorDisposer` instance should not dispose the comparator.

## The solution

I've added a flag `isActive`, which is initially set to `true`. The flag is set to `false` when a `ComparatorDisposer` is moved-from, to indicate that it's destructor should not restore `previousComparator`.

Additionally, I've declared copy constructor as deleted.


