### PR TITLE
utilities: handle exit code of copy command

### DIFF
--- a/ApprovalTests/launchers/SystemLauncher.h
+++ b/ApprovalTests/launchers/SystemLauncher.h
@@ -74,7 +74,7 @@ namespace ApprovalTests
             std::string launch = SystemUtils::isWindowsOs()
                                      ? ("start \"\" " + command)
                                      : (command + " &");
-            system(launch.c_str());
+            SystemUtils::runSystemCommand(launch);
             return true;
         }
     };

--- a/ApprovalTests/reporters/ClipboardReporter.h
+++ b/ApprovalTests/reporters/ClipboardReporter.h
@@ -68,7 +68,7 @@ namespace ApprovalTests
             }
             auto cmd =
                 std::string("echo ") + newClipboard + " | " + clipboardCommand;
-            system(cmd.c_str());
+            SystemUtils::runSystemCommand(cmd);
         }
     };
 }

--- a/ApprovalTests/utilities/FileUtilsSystemSpecific.h
+++ b/ApprovalTests/utilities/FileUtilsSystemSpecific.h
@@ -27,9 +27,9 @@ namespace ApprovalTests
         static void copyFile(const std::string& source,
                              const std::string& destination)
         {
-            system(getCommandLineForCopy(
-                       source, destination, SystemUtils::isWindowsOs())
-                       .c_str());
+            auto cmd = getCommandLineForCopy(
+                source, destination, SystemUtils::isWindowsOs());
+            SystemUtils::runSystemCommand(cmd);
         }
     };
 }

--- a/ApprovalTests/utilities/SystemUtils.h
+++ b/ApprovalTests/utilities/SystemUtils.h
@@ -183,6 +183,17 @@ namespace ApprovalTests
                 makeDirectory(fullFilePath);
             }
         }
+
+        static void runSystemCommand(const std::string& command)
+        {
+            int exitCode = system(command.c_str());
+
+            if (exitCode != 0)
+            {
+                throw std::runtime_error(command + ": failed with exit code " +
+                                         std::to_string(exitCode));
+            }
+        }
     };
 }
 #endif


### PR DESCRIPTION
## Description

When building another project including ApprovalTests as a git submodule, I've got the following warnings:

> warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]

caused by calls to `system()` (in `ClipboardReporter.h`, `FileUtilsSystemSpecific.h` and `SystemLauncher.h`).

## The solution

This commit replaces unchecked calls to `system()` with calls to a new method `SystemUtils::runSystemCommand()`, which throws `std::runtime_error` if the exit code is not 0.

Apart from suppressing the warning, this should help to locate a problem, if any of those commands actually fail.


