### PR TITLE
Add Support for SublimeMerge. Fixes #102

### DIFF
--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -163,7 +163,7 @@ namespace ApprovalTests
             APPROVAL_TESTS_MACROS_ENTRY(
                 SUBLIME_MERGE,
                 DiffInfo(
-                    "{ProgramFiles}Sublime Merge\\\\smerge.exe",
+                    "{ProgramFiles}Sublime Merge\\smerge.exe",
                     "mergetool --no-wait {Received} {Approved} -o {Approved}",
                     Type::TEXT))
 

--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -44,10 +44,12 @@ namespace ApprovalTests
                          Type::TEXT_AND_IMAGE))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE,
-                    DiffInfo("/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge",
-                             "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                             Type::TEXT))
+                SUBLIME_MERGE,
+                DiffInfo(
+                    "/Applications/Sublime "
+                    "Merge.app/Contents/SharedSupport/bin/smerge",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
                 KDIFF3,
@@ -76,28 +78,32 @@ namespace ApprovalTests
         namespace Linux
         {
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE_SNAP,
-                    DiffInfo("/snap/bin/sublime-merge",
-                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                            Type::TEXT))
+                SUBLIME_MERGE_SNAP,
+                DiffInfo(
+                    "/snap/bin/sublime-merge",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE_FLATPAK,
-                    DiffInfo("/var/lib/flatpak/exports/bin/com.sublimemerge.App",
-                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                            Type::TEXT))
+                SUBLIME_MERGE_FLATPAK,
+                DiffInfo(
+                    "/var/lib/flatpak/exports/bin/com.sublimemerge.App",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE,
-                    DiffInfo("smerge",
-                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                            Type::TEXT))
+                SUBLIME_MERGE,
+                DiffInfo(
+                    "smerge",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE_TARBALL,
-                    DiffInfo("/opt/sublime_merge/sublime_merge",
-                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                            Type::TEXT))
+                SUBLIME_MERGE_TARBALL,
+                DiffInfo(
+                    "/opt/sublime_merge/sublime_merge",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
             APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("kdiff3", Type::TEXT))
@@ -155,10 +161,11 @@ namespace ApprovalTests
                          Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                    SUBLIME_MERGE,
-                    DiffInfo("{ProgramFiles}Sublime Merge\\\\smerge.exe",
-                             "mergetool --no-wait {Received} {Approved} -o {Approved}",
-                             Type::TEXT))
+                SUBLIME_MERGE,
+                DiffInfo(
+                    "{ProgramFiles}Sublime Merge\\\\smerge.exe",
+                    "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                    Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
                 KDIFF3,

--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -44,6 +44,12 @@ namespace ApprovalTests
                          Type::TEXT_AND_IMAGE))
 
             APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE,
+                    DiffInfo("/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge",
+                             "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                             Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
                 KDIFF3,
                 DiffInfo("/Applications/kdiff3.app/Contents/MacOS/kdiff3",
                          "{Received} {Approved} -m",
@@ -69,6 +75,30 @@ namespace ApprovalTests
 
         namespace Linux
         {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE_SNAP,
+                    DiffInfo("/snap/bin/sublime-merge",
+                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                            Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE_FLATPAK,
+                    DiffInfo("/var/lib/flatpak/exports/bin/com.sublimemerge.App",
+                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                            Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE,
+                    DiffInfo("smerge",
+                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                            Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE_TARBALL,
+                    DiffInfo("/opt/sublime_merge/sublime_merge",
+                            "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                            Type::TEXT))
+
             // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
             APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("kdiff3", Type::TEXT))
 
@@ -123,6 +153,12 @@ namespace ApprovalTests
                 CODE_COMPARE,
                 DiffInfo("{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe",
                          Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                    SUBLIME_MERGE,
+                    DiffInfo("{ProgramFiles}Sublime Merge\\\\smerge.exe",
+                             "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                             Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
                 KDIFF3,

--- a/ApprovalTests/reporters/DiffPrograms.h
+++ b/ApprovalTests/reporters/DiffPrograms.h
@@ -92,14 +92,14 @@ namespace ApprovalTests
                     Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                SUBLIME_MERGE,
+                SUBLIME_MERGE_REPOSITORY_PACKAGE,
                 DiffInfo(
                     "smerge",
                     "mergetool --no-wait {Received} {Approved} -o {Approved}",
                     Type::TEXT))
 
             APPROVAL_TESTS_MACROS_ENTRY(
-                SUBLIME_MERGE_TARBALL,
+                SUBLIME_MERGE_DIRECT_DOWNLOAD,
                 DiffInfo(
                     "/opt/sublime_merge/sublime_merge",
                     "mergetool --no-wait {Received} {Approved} -o {Approved}",

--- a/ApprovalTests/reporters/LinuxReporters.h
+++ b/ApprovalTests/reporters/LinuxReporters.h
@@ -13,7 +13,7 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeSnapReporter()
-                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_SNAP())
+                : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_SNAP())
             {
                 launcher.setForeground(true);
             }
@@ -23,7 +23,8 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeFlatpakReporter()
-                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_FLATPAK())
+                : GenericDiffReporter(
+                      DiffPrograms::Linux::SUBLIME_MERGE_FLATPAK())
             {
                 launcher.setForeground(true);
             }
@@ -33,7 +34,7 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeReporter()
-                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE())
+                : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE())
             {
                 launcher.setForeground(true);
             }
@@ -43,7 +44,8 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeTarballReporter()
-                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_TARBALL())
+                : GenericDiffReporter(
+                      DiffPrograms::Linux::SUBLIME_MERGE_TARBALL())
             {
                 launcher.setForeground(true);
             }

--- a/ApprovalTests/reporters/LinuxReporters.h
+++ b/ApprovalTests/reporters/LinuxReporters.h
@@ -30,24 +30,38 @@ namespace ApprovalTests
             }
         };
 
-        class SublimeMergeReporter : public GenericDiffReporter
+        class SublimeMergeRepositoryPackageReporter : public GenericDiffReporter
         {
         public:
-            SublimeMergeReporter()
-                : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE())
+            SublimeMergeRepositoryPackageReporter()
+                : GenericDiffReporter(
+                      DiffPrograms::Linux::SUBLIME_MERGE_REPOSITORY_PACKAGE())
             {
                 launcher.setForeground(true);
             }
         };
 
-        class SublimeMergeTarballReporter : public GenericDiffReporter
+        class SublimeMergeDirectDownloadReporter : public GenericDiffReporter
         {
         public:
-            SublimeMergeTarballReporter()
+            SublimeMergeDirectDownloadReporter()
                 : GenericDiffReporter(
-                      DiffPrograms::Linux::SUBLIME_MERGE_TARBALL())
+                      DiffPrograms::Linux::SUBLIME_MERGE_DIRECT_DOWNLOAD())
             {
                 launcher.setForeground(true);
+            }
+        };
+
+        class SublimeMergeReporter : public FirstWorkingReporter
+        {
+        public:
+            SublimeMergeReporter()
+                : FirstWorkingReporter(
+                      {new SublimeMergeSnapReporter(),
+                       new SublimeMergeFlatpakReporter(),
+                       new SublimeMergeRepositoryPackageReporter(),
+                       new SublimeMergeDirectDownloadReporter()})
+            {
             }
         };
 
@@ -75,10 +89,7 @@ namespace ApprovalTests
                 : FirstWorkingReporter({
                       // begin-snippet: linux_diff_reporters
                       new MeldReporter(),
-                      new SublimeMergeSnapReporter(),
-                      new SublimeMergeFlatpakReporter(),
                       new SublimeMergeReporter(),
-                      new SublimeMergeTarballReporter(),
                       new KDiff3Reporter()
                       // end-snippet
                   })

--- a/ApprovalTests/reporters/LinuxReporters.h
+++ b/ApprovalTests/reporters/LinuxReporters.h
@@ -9,6 +9,46 @@ namespace ApprovalTests
 {
     namespace Linux
     {
+        class SublimeMergeSnapReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeSnapReporter()
+                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_SNAP())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
+        class SublimeMergeFlatpakReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeFlatpakReporter()
+                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_FLATPAK())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
+        class SublimeMergeReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeReporter()
+                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
+        class SublimeMergeTarballReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeTarballReporter()
+                    : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_TARBALL())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
         class KDiff3Reporter : public GenericDiffReporter
         {
         public:
@@ -33,6 +73,10 @@ namespace ApprovalTests
                 : FirstWorkingReporter({
                       // begin-snippet: linux_diff_reporters
                       new MeldReporter(),
+                      new SublimeMergeSnapReporter(),
+                      new SublimeMergeFlatpakReporter(),
+                      new SublimeMergeReporter(),
+                      new SublimeMergeTarballReporter(),
                       new KDiff3Reporter()
                       // end-snippet
                   })

--- a/ApprovalTests/reporters/MacReporters.h
+++ b/ApprovalTests/reporters/MacReporters.h
@@ -56,6 +56,16 @@ namespace ApprovalTests
             }
         };
 
+        class SublimeMergeReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeReporter()
+                    : GenericDiffReporter(DiffPrograms::Mac::SUBLIME_MERGE())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
         class KDiff3Reporter : public GenericDiffReporter
         {
         public:
@@ -92,6 +102,7 @@ namespace ApprovalTests
                       new DiffMergeReporter(),
                       new KaleidoscopeReporter(),
                       new P4MergeReporter(),
+                      new SublimeMergeReporter(),
                       new KDiff3Reporter(),
                       new TkDiffReporter(),
                       new VisualStudioCodeReporter()

--- a/ApprovalTests/reporters/MacReporters.h
+++ b/ApprovalTests/reporters/MacReporters.h
@@ -60,7 +60,7 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeReporter()
-                    : GenericDiffReporter(DiffPrograms::Mac::SUBLIME_MERGE())
+                : GenericDiffReporter(DiffPrograms::Mac::SUBLIME_MERGE())
             {
                 launcher.setForeground(true);
             }

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -143,7 +143,7 @@ namespace ApprovalTests
         {
         public:
             SublimeMergeReporter()
-                    : GenericDiffReporter(DiffPrograms::Windows::SUBLIME_MERGE())
+                : GenericDiffReporter(DiffPrograms::Windows::SUBLIME_MERGE())
             {
                 launcher.setForeground(true);
             }

--- a/ApprovalTests/reporters/WindowsReporters.h
+++ b/ApprovalTests/reporters/WindowsReporters.h
@@ -139,6 +139,16 @@ namespace ApprovalTests
             }
         };
 
+        class SublimeMergeReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeReporter()
+                    : GenericDiffReporter(DiffPrograms::Windows::SUBLIME_MERGE())
+            {
+                launcher.setForeground(true);
+            }
+        };
+
         class KDiff3Reporter : public GenericDiffReporter
         {
         public:
@@ -160,6 +170,7 @@ namespace ApprovalTests
                       new WinMergeReporter(),
                       new AraxisMergeReporter(),
                       new CodeCompareReporter(),
+                      new SublimeMergeReporter(),
                       new KDiff3Reporter(),
                       new VisualStudioCodeReporter(),
                       // end-snippet

--- a/build/relnotes_x.y.z.md
+++ b/build/relnotes_x.y.z.md
@@ -3,7 +3,7 @@
 * **Breaking changes**
     * None
 * **New features**
-    * None
+    * Added support for [SublimeMerge](https://www.sublimemerge.com/) on Linux, macOS, and Windows (#102)
 * **Bug fixes**
     * None
 * **Other changes**

--- a/doc/mdsource/Features.source.md
+++ b/doc/mdsource/Features.source.md
@@ -8,6 +8,10 @@ toc
 
 ## v.x.y.z
 
+### Support for SublimeMerge
+
+Added support for [SublimeMerge](https://www.sublimemerge.com/) on Linux, macOS, and Windows (#102)
+
 ## v.8.3.0
 
 ### Flexibility for adding custom merge tools

--- a/tests/DocTest_Tests/reporters/CommandLineReporterTests.cpp
+++ b/tests/DocTest_Tests/reporters/CommandLineReporterTests.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Test Command Lines")
         std::make_shared<Mac::DiffMergeReporter>(),
         std::make_shared<Mac::KaleidoscopeReporter>(),
         std::make_shared<Mac::P4MergeReporter>(),
+        std::make_shared<Mac::SublimeMergeReporter>(),
         std::make_shared<Mac::KDiff3Reporter>(),
         std::make_shared<Mac::TkDiffReporter>(),
         std::make_shared<Mac::VisualStudioCodeReporter>(),
@@ -44,11 +45,16 @@ TEST_CASE("Test Command Lines")
         std::make_shared<Windows::WinMergeReporter>(),
         std::make_shared<Windows::AraxisMergeReporter>(),
         std::make_shared<Windows::CodeCompareReporter>(),
+        std::make_shared<Windows::SublimeMergeReporter>(),
         std::make_shared<Windows::KDiff3Reporter>(),
         std::make_shared<Windows::VisualStudioCodeReporter>(),
 
         // Linux
         std::make_shared<Linux::MeldReporter>(),
+        std::make_shared<Linux::SublimeMergeSnapReporter>(),
+        std::make_shared<Linux::SublimeMergeFlatpakReporter>(),
+        std::make_shared<Linux::SublimeMergeReporter>(),
+        std::make_shared<Linux::SublimeMergeTarballReporter>(),
         std::make_shared<Linux::KDiff3Reporter>()};
     for (const auto& reporter : reporters)
     {

--- a/tests/DocTest_Tests/reporters/CommandLineReporterTests.cpp
+++ b/tests/DocTest_Tests/reporters/CommandLineReporterTests.cpp
@@ -53,8 +53,8 @@ TEST_CASE("Test Command Lines")
         std::make_shared<Linux::MeldReporter>(),
         std::make_shared<Linux::SublimeMergeSnapReporter>(),
         std::make_shared<Linux::SublimeMergeFlatpakReporter>(),
-        std::make_shared<Linux::SublimeMergeReporter>(),
-        std::make_shared<Linux::SublimeMergeTarballReporter>(),
+        std::make_shared<Linux::SublimeMergeRepositoryPackageReporter>(),
+        std::make_shared<Linux::SublimeMergeDirectDownloadReporter>(),
         std::make_shared<Linux::KDiff3Reporter>()};
     for (const auto& reporter : reporters)
     {

--- a/tests/DocTest_Tests/reporters/approval_tests/CommandLineReporterTests.Test_Command_Lines.approved.txt
+++ b/tests/DocTest_Tests/reporters/approval_tests/CommandLineReporterTests.Test_Command_Lines.approved.txt
@@ -18,6 +18,10 @@ windows: start "" "/Applications/p4merge.app/Contents/MacOS/p4merge" "a.txt" "b.
 unix   : "/Applications/p4merge.app/Contents/MacOS/p4merge" "a.txt" "b.txt" &
 cygwin : "$(cygpath '/Applications/p4merge.app/Contents/MacOS/p4merge')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" &
 
+windows: cmd /S /C ""/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+
 windows: start "" "/Applications/kdiff3.app/Contents/MacOS/kdiff3" "a.txt" "b.txt" -m
 unix   : "/Applications/kdiff3.app/Contents/MacOS/kdiff3" "a.txt" "b.txt" -m &
 cygwin : "$(cygpath '/Applications/kdiff3.app/Contents/MacOS/kdiff3')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -m &
@@ -66,6 +70,10 @@ windows: start "" "{ProgramFiles}Devart\Code Compare\CodeCompare.exe" "a.txt" "b
 unix   : "{ProgramFiles}Devart\Code Compare\CodeCompare.exe" "a.txt" "b.txt" &
 cygwin : "$(cygpath '{ProgramFiles}Devart\Code Compare\CodeCompare.exe')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" &
 
+windows: cmd /S /C ""{ProgramFiles}Sublime Merge\\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "{ProgramFiles}Sublime Merge\\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '{ProgramFiles}Sublime Merge\\smerge.exe')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+
 windows: start "" "{ProgramFiles}KDiff3\kdiff3.exe" "a.txt" "b.txt"
 unix   : "{ProgramFiles}KDiff3\kdiff3.exe" "a.txt" "b.txt" &
 cygwin : "$(cygpath '{ProgramFiles}KDiff3\kdiff3.exe')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" &
@@ -77,6 +85,22 @@ cygwin : "$(cygpath '{ProgramFiles}Microsoft VS Code\Code.exe')" -d "$(cygpath -
 windows: start "" "meld" "a.txt" "b.txt"
 unix   : "meld" "a.txt" "b.txt" &
 cygwin : "$(cygpath 'meld')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" &
+
+windows: cmd /S /C ""/snap/bin/sublime-merge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "/snap/bin/sublime-merge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '/snap/bin/sublime-merge')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+
+windows: cmd /S /C ""/var/lib/flatpak/exports/bin/com.sublimemerge.App" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "/var/lib/flatpak/exports/bin/com.sublimemerge.App" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '/var/lib/flatpak/exports/bin/com.sublimemerge.App')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+
+windows: cmd /S /C ""smerge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "smerge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath 'smerge')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+
+windows: cmd /S /C ""/opt/sublime_merge/sublime_merge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "/opt/sublime_merge/sublime_merge" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '/opt/sublime_merge/sublime_merge')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
 
 windows: start "" "kdiff3" "a.txt" "b.txt"
 unix   : "kdiff3" "a.txt" "b.txt" &

--- a/tests/DocTest_Tests/reporters/approval_tests/CommandLineReporterTests.Test_Command_Lines.approved.txt
+++ b/tests/DocTest_Tests/reporters/approval_tests/CommandLineReporterTests.Test_Command_Lines.approved.txt
@@ -70,9 +70,9 @@ windows: start "" "{ProgramFiles}Devart\Code Compare\CodeCompare.exe" "a.txt" "b
 unix   : "{ProgramFiles}Devart\Code Compare\CodeCompare.exe" "a.txt" "b.txt" &
 cygwin : "$(cygpath '{ProgramFiles}Devart\Code Compare\CodeCompare.exe')" "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" &
 
-windows: cmd /S /C ""{ProgramFiles}Sublime Merge\\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
-unix   : "{ProgramFiles}Sublime Merge\\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
-cygwin : "$(cygpath '{ProgramFiles}Sublime Merge\\smerge.exe')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
+windows: cmd /S /C ""{ProgramFiles}Sublime Merge\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt""
+unix   : "{ProgramFiles}Sublime Merge\smerge.exe" mergetool --no-wait "a.txt" "b.txt" -o "b.txt"
+cygwin : "$(cygpath '{ProgramFiles}Sublime Merge\smerge.exe')" mergetool --no-wait "$(cygpath -aw 'a.txt')" "$(cygpath -aw 'b.txt')" -o "$(cygpath -aw 'b.txt')"
 
 windows: start "" "{ProgramFiles}KDiff3\kdiff3.exe" "a.txt" "b.txt"
 unix   : "{ProgramFiles}KDiff3\kdiff3.exe" "a.txt" "b.txt" &


### PR DESCRIPTION
## Description

Fixes #102.
ApprovalTests can now use the [SublimeMerge](https://www.sublimemerge.com/) tool on Linux, macOS, and Windows.

## Solution

I followed the instructions at on how to add new merge tools from [here](/doc/how_tos/SubmitANewReporterToApprovalTests.md#top).
To support multiple versions of SublimeMerge on Linux, I added extra `DiffInfo`'s and Reporter classes with appropriate suffixes to distinguish between them.
This is not ideal because it adds clutter and more boilerplate, but I think this can be fixed better in a future pull request meant to simplify how merge tools are added.

### Handling Multiple Installations on Linux

On Linux, there is additional support for the SublimeMerge [Snap](https://snapcraft.io/sublime-merge), [Flatpak](https://flathub.org/apps/details/com.sublimemerge.App), and [tarball](https://www.sublimemerge.com/download) installations.
Other info about calling SublimeMerge from the command-line can be found [here](https://www.sublimemerge.com/docs/command_line).
In the case of multiple installation on Linux, the one chosen is determined as follows:
1. Snap
2. Flatpak
3. Any tool on the path named "smerge"
4. The installed tarball

Please note that while the Flatpak package is official, the Snap package is unofficial at this time.

## Remaining Work

The markdown snippets and single-header file will need to be regenerated. I haven't got to this yet because it is a bit of pain when it comes to getting the dependencies on Ubuntu.

I have verified the merge tool is called correctly on macOS, Windows, and on Linux for the Snap package. I should probably test for the other alternatives on Linux as well.