### PR TITLE
[WIP] Add namer that allows users full customization

### DIFF
--- a/ApprovalTests/namers/CustomNamer.h
+++ b/ApprovalTests/namers/CustomNamer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "ApprovalTestNamer.h"
+#include "../Approvals.h"
+
+#include <functional>
+#include <memory>
+
+namespace ApprovalTests
+{
+    class CustomNamer : public ApprovalTestNamer
+    {
+    public:
+        template <typename ReceivedNameFn, typename ApprovedNameFn>
+        CustomNamer(ReceivedNameFn&& receivedNameFn, ApprovedNameFn&& approvedNameFn)
+            : receivedNameFn(std::forward<ReceivedNameFn>(receivedNameFn))
+            , approvedNameFn(std::forward<ApprovedNameFn>(approvedNameFn))
+        {
+        }
+
+        virtual std::string getApprovedFile(std::string extensionWithDot) const override
+        {
+            return approvedNameFn(ApprovalTestNamer::getCurrentTest(), extensionWithDot);
+        }
+
+        virtual std::string getReceivedFile(std::string extensionWithDot) const override
+        {
+            return receivedNameFn(ApprovalTestNamer::getCurrentTest(), extensionWithDot);
+        }
+
+        template <typename ReceivedNameFn, typename ApprovedNameFn>
+        static ApprovalTests::DefaultNamerDisposer
+        useAsDefaultNamer(ReceivedNameFn receivedNameFn, ApprovedNameFn approvedNameFn)
+        {
+            return ApprovalTests::Approvals::useAsDefaultNamer(
+                [receivedNameFn, approvedNameFn]() {
+                    return std::make_shared<CustomNamer>(receivedNameFn, approvedNameFn);
+                });
+        }
+
+    private:
+        std::function<std::string(TestName, std::string)> receivedNameFn;
+        std::function<std::string(TestName, std::string)> approvedNameFn;
+    };
+
+    template <typename ReceivedNameFn, typename ApprovedNameFn>
+    inline auto makeCustomNamer(ReceivedNameFn&& receivedNameFn,
+                                ApprovedNameFn&& approvedNameFn)
+        -> std::shared_ptr<CustomNamer>
+    {
+        return std::make_shared<CustomNamer>(
+            std::forward<ReceivedNameFn>(receivedNameFn),
+            std::forward<ApprovedNameFn>(approvedNameFn));
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a namer can be used to completely cusomize where approved and received files will be stored. This allows to e.g. make the path dependend on the run time location of the test binary instead of the source location for cases where the machine running the tests might not even have the source files checked out, as mentioned in #128 .

## The solution

The new namer allows the user to supply two function objects to compute the path of the received and approved file respectively, given the `TestName` object and the expected file extension. That way these function objects may or may not use the file location stored in the `TestName` object depending on the need of the user.

However, I'm not satisfied with this solution, as it doesn't compose with other existing namers. For example, there already is a namer to store approved and received files in different directories, but when using this new namer to use a custom location the user has to manually re-implement that in the function objects they provide to the namer. Moreover, with GoogleTest ApprovalTests.cpp will still try to find the source file and print an error if it cannot find it, even if the path isn't even used later on.

This is meant as a basis to develop other ideas and further discussions and expected to change a lot, which is why I didn't add documentation or tests for this yet.

