### PR TITLE
Update DocTestApprovals.h

### DIFF
--- a/ApprovalTests/integrations/doctest/DocTestApprovals.h
+++ b/ApprovalTests/integrations/doctest/DocTestApprovals.h
@@ -99,7 +99,11 @@ namespace ApprovalTests
             {
 
                 currentTest.sections.emplace_back(testInfo.m_name);
+#if DOCTEST_VERSION >= 20308
+                currentTest.setFileName(testInfo.m_file.c_str());
+#else
                 currentTest.setFileName(testInfo.m_file);
+#endif
                 ApprovalTestNamer::currentTest(&currentTest);
             }
 


### PR DESCRIPTION
Fixed compatibility with doctest 2.3.8
type of doctest::TestCaseData::m_file was changed from const char* to doctest::String in 2.3.8