### PR TITLE
Fix -Wdeprecated-copy-dtor warnings (#163)

### DIFF
--- a/ApprovalTests/namers/DefaultNamerDisposer.h
+++ b/ApprovalTests/namers/DefaultNamerDisposer.h
@@ -13,6 +13,7 @@ namespace ApprovalTests
 
     public:
         explicit DefaultNamerDisposer(NamerCreator namerCreator);
+        DefaultNamerDisposer(const DefaultNamerDisposer&) = default;
 
         ~DefaultNamerDisposer();
     };

--- a/ApprovalTests/namers/SectionNameDisposer.h
+++ b/ApprovalTests/namers/SectionNameDisposer.h
@@ -9,6 +9,7 @@ namespace ApprovalTests
     {
     public:
         SectionNameDisposer(TestName& currentTest_, const std::string& scope_name);
+        SectionNameDisposer(const SectionNameDisposer&) = default;
 
         ~SectionNameDisposer();
 

--- a/ApprovalTests/namers/SubdirectoryDisposer.h
+++ b/ApprovalTests/namers/SubdirectoryDisposer.h
@@ -14,6 +14,7 @@ namespace ApprovalTests
 
     public:
         explicit SubdirectoryDisposer(std::string subdirectory);
+        SubdirectoryDisposer(const SubdirectoryDisposer&) = default;
 
         ~SubdirectoryDisposer();
     };

--- a/ApprovalTests/reporters/FrontLoadedReporterDisposer.h
+++ b/ApprovalTests/reporters/FrontLoadedReporterDisposer.h
@@ -13,6 +13,7 @@ namespace ApprovalTests
 
     public:
         explicit FrontLoadedReporterDisposer(const std::shared_ptr<Reporter>& reporter);
+        FrontLoadedReporterDisposer(const FrontLoadedReporterDisposer&) = default;
 
         ~FrontLoadedReporterDisposer();
     };


### PR DESCRIPTION
## Description

The PR fixes a few `Wdeprecated-copy-dtor` warnings which are raised by Clang 11.

## The solution

The compiler complains that the definition of an implicit copy constructor is deprecated when the class has a user-declared destructor. This PR adds default copy constructors to all classes where the warning occurs.

Fixes #163