### PR TITLE
Add GitHub Actions workflow to run all python tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python tests
 
 on:
   push:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,9 +5,11 @@ name: Python application
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,13 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - Check out ApprovalTests.cpp
+      uses: actions/checkout@v2
+      with:
+        path: ApprovalTests/ApprovalTests.cpp
 
     - name: Check out claremacrae fork of conan-center-index
       uses: actions/checkout@v2
       with:
         repository: claremacrae/conan-center-index
-        path: conan-center-index-claremacrae
+        path: conan/conan-center-index-claremacrae
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -32,6 +35,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        cd ApprovalTests/ApprovalTests.cpp
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r build/requirements.txt
@@ -39,6 +43,7 @@ jobs:
 
     - name: Lint with flake8
       run: |
+        cd ApprovalTests/ApprovalTests.cpp
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
@@ -49,10 +54,12 @@ jobs:
         pwd
         ls -ls
         ls -ls ..
+        cd ApprovalTests/ApprovalTests.cpp
         cd build
         python -m unittest discover -s tests --verbose
 
     - name: Test doc/sphinx with pytest
       run: |
+        cd ApprovalTests/ApprovalTests.cpp
         cd doc/sphinx/tests
         python -m unittest discover -t ../.. --verbose

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,6 +39,10 @@ jobs:
         cd build
         ./install_python_requirements.sh
 
+    - uses: r-lib/actions/setup-pandoc@v1
+      with:
+        pandoc-version: '2.9.2.1'
+
     - name: Lint with flake8
       run: |
         cd ApprovalTests/ApprovalTests.cpp

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - Check out ApprovalTests.cpp
+    - name: Check out ApprovalTests.cpp
       uses: actions/checkout@v2
       with:
         path: ApprovalTests/ApprovalTests.cpp

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         cd ApprovalTests/ApprovalTests.cpp
         sudo apt-get install pandoc
+        pandoc --version
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r build/requirements.txt

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,4 +36,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest build/tests
+        # pytest doc/sphinx/tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,8 +38,17 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Check out claremacrae fork of conan-center-index
+      uses: actions/checkout@v2
+      with:
+        repository: claremacrae/conan-center-index
+        path: ../conan-center-index-claremacrae
+
     - name: Test build/ with pytest
       run: |
+        pwd
+        ls -ls
+        ls -ls ..
         cd build
         python -m unittest discover -s tests --verbose
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,26 +18,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r build/requirements.txt
         pip install -r doc/requirements.txt
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test build/ with pytest
       run: |
         cd build
         python -m unittest discover -s tests --verbose
+
     - name: Test doc/sphinx with pytest
       run: |
         cd doc/sphinx/tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -52,9 +52,6 @@ jobs:
 
     - name: Test build/ with pytest
       run: |
-        pwd
-        ls -ls
-        ls -ls ..
         cd ApprovalTests/ApprovalTests.cpp
         cd build
         python -m unittest discover -s tests --verbose

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -33,15 +33,15 @@ jobs:
       with:
         python-version: 3.8
 
+    - uses: r-lib/actions/setup-pandoc@v1
+      with:
+        pandoc-version: '2.9.2.1'
+
     - name: Install dependencies
       run: |
         cd ApprovalTests/ApprovalTests.cpp
         cd build
         ./install_python_requirements.sh
-
-    - uses: r-lib/actions/setup-pandoc@v1
-      with:
-        pandoc-version: '2.9.2.1'
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,7 +36,9 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test build/ with pytest
       run: |
-        pytest build/tests
+        cd build
+        python -m unittest discover -s tests --verbose
     - name: Test doc/sphinx with pytest
       run: |
-        pytest doc/sphinx/tests
+        cd doc/sphinx/tests
+        python -m unittest discover -t ../.. --verbose

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,10 +38,10 @@ jobs:
         cd ApprovalTests/ApprovalTests.cpp
         sudo apt-get install pandoc
         pandoc --version
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install -r build/requirements.txt
-        pip install -r doc/requirements.txt
+        python3 -m pip install --upgrade pip
+        pip3 install flake8 pytest
+        pip3 install -r build/requirements.txt
+        pip3 install -r doc/requirements.txt
 
     - name: Lint with flake8
       run: |
@@ -55,10 +55,10 @@ jobs:
       run: |
         cd ApprovalTests/ApprovalTests.cpp
         cd build
-        python -m unittest discover -s tests --verbose
+        python3 -m unittest discover -s tests --verbose
 
     - name: Test doc/sphinx with pytest
       run: |
         cd ApprovalTests/ApprovalTests.cpp
         cd doc/sphinx/tests
-        python -m unittest discover -t ../.. --verbose
+        python3 -m unittest discover -t ../.. --verbose

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: claremacrae/conan-center-index
-        path: ../conan-center-index-claremacrae
+        path: conan-center-index-claremacrae
 
     - name: Test build/ with pytest
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r build/requirements.txt
+        pip install -r doc/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Check out claremacrae fork of conan-center-index
+      uses: actions/checkout@v2
+      with:
+        repository: claremacrae/conan-center-index
+        path: conan-center-index-claremacrae
+
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -37,12 +43,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-    - name: Check out claremacrae fork of conan-center-index
-      uses: actions/checkout@v2
-      with:
-        repository: claremacrae/conan-center-index
-        path: conan-center-index-claremacrae
 
     - name: Test build/ with pytest
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python tests
+name: python-tests
 
 on:
   push:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd ApprovalTests/ApprovalTests.cpp
+        sudo apt-get install pandoc
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r build/requirements.txt

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,12 +36,8 @@ jobs:
     - name: Install dependencies
       run: |
         cd ApprovalTests/ApprovalTests.cpp
-        sudo apt-get install pandoc
-        pandoc --version
-        python3 -m pip install --upgrade pip
-        pip3 install flake8 pytest
-        pip3 install -r build/requirements.txt
-        pip3 install -r doc/requirements.txt
+        cd build
+        ./install_python_requirements.sh
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test build/ with pytest
       run: |
         pytest build/tests
-        # pytest doc/sphinx/tests
+    - name: Test doc/sphinx with pytest
+      run: |
+        pytest doc/sphinx/tests

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To change this file edit the source file and then execute ./run_markdown_templat
 [![Build Status](https://api.travis-ci.org/approvals/ApprovalTests.cpp.svg?branch=master)](https://travis-ci.org/approvals/ApprovalTests.cpp)
 [![Build status](https://ci.appveyor.com/api/projects/status/lf3i76ije89oihi5?svg=true)](https://ci.appveyor.com/project/isidore/approvaltests-cpp)
 [![Actions Status](https://github.com/approvals/ApprovalTests.cpp/workflows/build/badge.svg)](https://github.com/approvals/ApprovalTests.cpp/actions)
+[![Python tests](https://github.com/claremacrae/ApprovalTests.cpp/workflows/Python%20tests/badge.svg)](https://github.com/approvals/ApprovalTests.cpp/actions)
 [![Documentation Status](https://readthedocs.org/projects/approvaltestscpp/badge/?version=latest)](https://approvaltestscpp.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](/CODE_OF_CONDUCT.md#top)

--- a/build/install_python_requirements.sh
+++ b/build/install_python_requirements.sh
@@ -6,7 +6,8 @@ set -o pipefail
 
 # To update, use:
 #   pip3 install --upgrade --no-cache-dir
-sudo apt-get install pandoc
+# Exactly pandoc 2.9.2.1 is required
+#sudo apt-get install pandoc
 pandoc --version
 python3 -m pip install --upgrade pip
 pip3 install flake8 pytest

--- a/build/install_python_requirements.sh
+++ b/build/install_python_requirements.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Force execution to halt if there are any errors in this script:
+set -e
+set -o pipefail
+
 # To update, use:
 #   pip3 install --upgrade --no-cache-dir
 sudo apt-get install pandoc

--- a/build/install_python_requirements.sh
+++ b/build/install_python_requirements.sh
@@ -2,5 +2,9 @@
 
 # To update, use:
 #   pip3 install --upgrade --no-cache-dir
+sudo apt-get install pandoc
+pandoc --version
+python3 -m pip install --upgrade pip
+pip3 install flake8 pytest
 pip3 install -r requirements.txt
 pip3 install -r ../doc/requirements.txt

--- a/build/scripts/conan_release_details.py
+++ b/build/scripts/conan_release_details.py
@@ -12,7 +12,6 @@ class ConanReleaseDetails:
     @staticmethod
     def get_conan_repo_directory() -> str:
         possibles = [
-            '../conan-center-index-claremacrae',  # github actions
             '../../conan-center-index-claremacrae',  # llewellyn
             '../../../conan/conan-center-index-claremacrae'  # clare
         ]

--- a/build/scripts/conan_release_details.py
+++ b/build/scripts/conan_release_details.py
@@ -12,6 +12,7 @@ class ConanReleaseDetails:
     @staticmethod
     def get_conan_repo_directory() -> str:
         possibles = [
+            '../conan-center-index-claremacrae',  # github actions
             '../../conan-center-index-claremacrae',  # llewellyn
             '../../../conan/conan-center-index-claremacrae'  # clare
         ]

--- a/doc/sphinx/tests/test_markdown_conversion.py
+++ b/doc/sphinx/tests/test_markdown_conversion.py
@@ -6,9 +6,7 @@ from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffRep
 
 import sys
 
-sys.path.append('../../')
 sys.path.append('../../..')
-sys.path.append('../../../..')
 
 from doc.sphinx import markdown_conversion
 

--- a/doc/sphinx/tests/test_markdown_conversion.py
+++ b/doc/sphinx/tests/test_markdown_conversion.py
@@ -43,19 +43,19 @@ class TestWholeConversion(unittest.TestCase):
 
         converted_markdown, converted_rst = markdown_conversion.convert_markdown_text_to_restructured_text(input, '')
 
-        # reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
+        reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
 
         failure_count = 0
 
         try:
             namer = Namer('.md')
-            verify_with_namer(converted_markdown, namer)
+            verify_with_namer(converted_markdown, namer, reporter)
         except(ApprovalException):
             failure_count += 1
 
         try:
             namer = Namer('.rst')
-            verify_with_namer(converted_rst, namer)
+            verify_with_namer(converted_rst, namer, reporter)
         except(ApprovalException):
             failure_count += 1
 

--- a/doc/sphinx/tests/test_markdown_conversion.py
+++ b/doc/sphinx/tests/test_markdown_conversion.py
@@ -43,19 +43,19 @@ class TestWholeConversion(unittest.TestCase):
 
         converted_markdown, converted_rst = markdown_conversion.convert_markdown_text_to_restructured_text(input, '')
 
-        reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
+        # reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
 
         failure_count = 0
 
         try:
             namer = Namer('.md')
-            verify_with_namer(converted_markdown, namer, reporter)
+            verify_with_namer(converted_markdown, namer)
         except(ApprovalException):
             failure_count += 1
 
         try:
             namer = Namer('.rst')
-            verify_with_namer(converted_rst, namer, reporter)
+            verify_with_namer(converted_rst, namer)
         except(ApprovalException):
             failure_count += 1
 

--- a/doc/sphinx/tests/test_markdown_conversion.py
+++ b/doc/sphinx/tests/test_markdown_conversion.py
@@ -6,7 +6,9 @@ from approvaltests.reporters.generic_diff_reporter_factory import GenericDiffRep
 
 import sys
 
+sys.path.append('../../')
 sys.path.append('../../..')
+sys.path.append('../../../..')
 
 from doc.sphinx import markdown_conversion
 

--- a/doc/sphinx/tests/test_markdown_conversion.py
+++ b/doc/sphinx/tests/test_markdown_conversion.py
@@ -43,7 +43,8 @@ class TestWholeConversion(unittest.TestCase):
 
         converted_markdown, converted_rst = markdown_conversion.convert_markdown_text_to_restructured_text(input, '')
 
-        reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
+        # reporter = GenericDiffReporterFactory().get('AraxisMergeMac')
+        reporter = None
 
         failure_count = 0
 


### PR DESCRIPTION
This adds a GitHub Actions workflow, in a separate file, `.github/workflows/github_actions_build.yml`, to set up an environment and then run all our python tests, of both the release-building scripts and the Sphinx documentation-building scripts.

It also adds a build-badge for this new workflow.