### PR TITLE
#213 Fix bug with {fmt} integration

### DIFF
--- a/ApprovalTests/integrations/fmt/FmtToString.h
+++ b/ApprovalTests/integrations/fmt/FmtToString.h
@@ -1,5 +1,8 @@
 #pragma once
 #ifdef FMT_VERSION
+
+#include <fmt/format.h> // for fmt::to_string()
+
 namespace ApprovalTests
 {
     class FmtToString


### PR DESCRIPTION
## This should be small

Small pull requests are great and easy for me to understand and accept
Please try prefix every commits in the pull request with  [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)
| Prefix | Meaning |
|--------|---------|
| e   | development enviroment only - not production|
| d   | documentation only|
| t   | tests only|
| R!! | Refactoring |
| B!! | Bug Fix |
| F!! | New Feature |

## But it's not small!

Then you should setup a remote pairing session with Llewellyn ( llewellyn.falco@gmail.com )
Usually the sessions are between 45-90 minutes.

assuming you still feel it is small, please include

## Description

See linked issue https://github.com/approvals/ApprovalTests.cpp/issues/213.

TL;DR `{fmt}` integration is triggered by FMT_VERSION define that is provided by `<fmt/core.h>`, while feature itself is using `fmt::to_string()` that is defined in `<fmt/format.h>` that causes a bug.

## The solution

Include `<fmt/format.h>` in case `{fmt}` integration is triggered, so even if user included only `<fmt/core.h>`, the library provides itself with needed header to work correctly.

## Notation

I prefer lots of very small commits prefixed with [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)


